### PR TITLE
Implement initial MetaboMind modules

### DIFF
--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Tuple
+
+import openai
+
+from memory.intention_graph import IntentionGraph
+from metabo_rules import METABO_RULES
+from reasoning.entropy_analyzer import entropy_of_graph
+
+
+class CycleManager:
+    """Manages Metabo cycles including graph updates and reflections."""
+
+    def __init__(self, api_key: str | None = None):
+        key = api_key or os.getenv("OPENAI_API_KEY")
+        self.client = openai.OpenAI(api_key=key) if key else None
+        self.graph = IntentionGraph()
+        self.cycle = 0
+        self.logs: List[str] = []
+
+    def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
+        """Use OpenAI to extract triples from text."""
+        if not self.client:
+            words = text.split()
+            if len(words) >= 3:
+                return [(words[0], words[1], " ".join(words[2:]))]
+            return []
+
+        prompt = (
+            "Extrahiere (Subjekt, Relation, Objekt)-Tripel aus folgendem Text. "
+            "Antworte im JSON-Listenformat: [[\"subj\", \"rel\", \"obj\"], ...]."
+        )
+        response = self.client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            temperature=0,
+            messages=[
+                {"role": "system", "content": METABO_RULES},
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": text},
+            ],
+        )
+        content = response.choices[0].message.content
+        try:
+            triplets = json.loads(content)
+            return [(t[0], t[1], t[2]) for t in triplets]
+        except Exception:
+            return []
+
+    def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> str:
+        """Ask the model to reflect on new triples and emotion change."""
+        prompt = (
+            "Formuliere basierend auf den neuen Tripeln und der Emotion (Entropie-Änderung) "
+            "eine kurze Reflexion, wie der Wissensgraph verbessert werden kann."
+        )
+        content = f"Triples: {triplets}\nEmotion: {emotion:.3f}"
+        if not self.client:
+            return "No reflection available without OpenAI API key."
+
+        response = self.client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            temperature=0,
+            messages=[
+                {"role": "system", "content": METABO_RULES},
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": content},
+            ],
+        )
+        return response.choices[0].message.content.strip()
+
+    def run_cycle(self, text: str) -> str:
+        """Run a single Metabo cycle with the provided text."""
+        self.cycle += 1
+        before = entropy_of_graph(self.graph.snapshot())
+        triplets = self._extract_triplets(text)
+        if triplets:
+            self.graph.add_triplets(triplets)
+        after = entropy_of_graph(self.graph.snapshot())
+        emotion = after - before
+        reflection = self._reflect(triplets, emotion)
+        log_entry = (
+            f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
+            f"emotion={emotion:.3f}"
+        )
+        self.logs.append(log_entry)
+        return (
+            f"[Cycle {self.cycle}] Entropy before: {before:.3f}, "
+            f"after: {after:.3f}, Emotion: {emotion:+.3f}\n"
+            f"Reflection: {reflection}\n[Logging] {log_entry}"
+        )

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+from control.cycle_manager import CycleManager
+from metabo_rules import METABO_RULES
+
+
+def main():
+    print(METABO_RULES)
+    manager = CycleManager()
+    text = input("Eingabe: ")
+    result = manager.run_cycle(text)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/intention_graph.py
+++ b/memory/intention_graph.py
@@ -1,0 +1,20 @@
+import networkx as nx
+from typing import List, Tuple
+
+class IntentionGraph:
+    """Graph storing intention triples."""
+
+    def __init__(self):
+        # using directed multigraph to allow multiple relations between nodes
+        self.graph = nx.MultiDiGraph()
+
+    def add_triplets(self, triplets: List[Tuple[str, str, str]]):
+        """Add a list of (subject, relation, object) triples to the graph."""
+        for subj, rel, obj in triplets:
+            self.graph.add_node(subj)
+            self.graph.add_node(obj)
+            self.graph.add_edge(subj, obj, relation=rel)
+
+    def snapshot(self) -> nx.MultiDiGraph:
+        """Return a copy of the current graph."""
+        return self.graph.copy()

--- a/metabo_rules.py
+++ b/metabo_rules.py
@@ -1,0 +1,7 @@
+METABO_RULES = """Metabo-Regeln:
+1. R0 – Symbolische Verknüpfung: Baue und erweitere einen symbolischen Wissensgraphen (IntentionGraph) mit Struktur und Verknüpfungen.
+2. R1 – Entropie-Messung: Implementiere Methoden zur quantitativen Bewertung von Ordnern und Verbindungen.
+3. R4 – Emotionsregel: Werte Entropie-Änderung aus und interpretiere sie als emotionales Signal (Belohnung/Rückmeldung für den nächsten Zyklus).
+4. R3 – Selbstreflexion: Baue eine einfache Reflexionsschleife ein, in der das LLM seine eigenen Tripel bewertet und verbessert.
+5. R5 – Protokollierung: Logge jede Zyklus-Iteration mit Entropiewerten und Reflexionsänderungen.
+"""

--- a/reasoning/entropy_analyzer.py
+++ b/reasoning/entropy_analyzer.py
@@ -1,0 +1,17 @@
+import math
+from collections import Counter
+import networkx as nx
+
+
+def entropy_of_graph(graph: nx.Graph) -> float:
+    """Compute Shannon entropy of node degree distribution."""
+    degrees = [d for _, d in graph.degree()]
+    if not degrees:
+        return 0.0
+    count = Counter(degrees)
+    total = sum(count.values())
+    entropy = 0.0
+    for freq in count.values():
+        p = freq / total
+        entropy -= p * math.log(p, 2)
+    return entropy


### PR DESCRIPTION
## Summary
- implement `IntentionGraph` for tracking subject–relation–object triples
- compute Shannon entropy of node degree distribution
- manage reasoning cycles via `CycleManager`
- provide a simple CLI in `main.py`
- localize prompts and display Metabo rules on startup
- include Metabo rules with every OpenAI prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py <<'EOF'
Ich will Freiheit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686c00c37aa4832eb47b779fd2337c8e