### PR TITLE
Add logger support in main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 secrets/
 **/__pycache__
+memory/graph.gml
+logs/metabo_log.jsonl

--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -5,8 +5,12 @@ from typing import List, Tuple
 
 import openai
 
+from logs.logger import MetaboLogger
+from reasoning.emotion import interpret_emotion
+
+from triplet_parser_llm import extract_triplets_via_llm
+
 from reflection.reflection_engine import generate_reflection
-from utils.json_utils import parse_json_safe
 
 from memory.intention_graph import IntentionGraph
 from metabo_rules import METABO_RULES
@@ -16,39 +20,22 @@ from reasoning.entropy_analyzer import entropy_of_graph
 class CycleManager:
     """Manages Metabo cycles including graph updates and reflections."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, logger: MetaboLogger | None = None):
         key = api_key or os.getenv("OPENAI_API_KEY")
         self.api_key = key
+        if key:
+            openai.api_key = key
         self.client = openai.OpenAI(api_key=key) if key else None
         self.graph = IntentionGraph()
         self.cycle = 0
+        self.logger = logger
         self.logs: List[str] = []
 
     def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
-        """Use OpenAI to extract triples from text."""
-        if not self.client:
-            words = text.split()
-            if len(words) >= 3:
-                return [(words[0], words[1], " ".join(words[2:]))]
-            return []
-
-        prompt = (
-            "Extrahiere (Subjekt, Relation, Objekt)-Tripel aus folgendem Text. "
-            "Antworte im JSON-Listenformat: [[\"subj\", \"rel\", \"obj\"], ...]."
-        )
-        response = self.client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            temperature=0,
-            messages=[
-                {"role": "system", "content": METABO_RULES},
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": text},
-            ],
-        )
-        content = response.choices[0].message.content
-        data = parse_json_safe(content)
-        if isinstance(data, list):
-            return [(t[0], t[1], t[2]) for t in data]
+        """Naive fallback extraction of triples when no API key is available."""
+        words = text.split()
+        if len(words) >= 3:
+            return [(words[0], words[1], " ".join(words[2:]))]
         return []
 
     def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> dict:
@@ -60,22 +47,36 @@ class CycleManager:
         """Run a single Metabo cycle with the provided text."""
         self.cycle += 1
         before = entropy_of_graph(self.graph.snapshot())
-        triplets = self._extract_triplets(text)
+        if self.api_key:
+            triplets = extract_triplets_via_llm(text)
+        else:
+            triplets = self._extract_triplets(text)
         if triplets:
             self.graph.add_triplets(triplets)
         after = entropy_of_graph(self.graph.snapshot())
-        emotion = after - before
-        reflection = self._reflect(triplets, emotion)
+        emo = interpret_emotion(before, after)
+        reflection = self._reflect(triplets, emo["delta"])
         log_entry = (
             f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
-            f"emotion={emotion:.3f}"
+            f"emotion={emo['delta']:.3f}"
         )
         self.logs.append(log_entry)
         self.graph.save_graph()
 
+        if self.logger:
+            self.logger.log_cycle(
+                input_text=text,
+                reflection=reflection["reflection"],
+                triplets=triplets,
+                ent_before=before,
+                ent_after=after,
+                emotion=emo["emotion"],
+                intensity=emo["intensity"],
+            )
+
         return (
             f"[Cycle {self.cycle}] Entropy before: {before:.3f}, "
-            f"after: {after:.3f}, Emotion: {emotion:+.3f}\n"
+            f"after: {after:.3f}, Emotion: {emo['delta']:+.3f}\n"
             f"Reflection: {reflection['reflection']}\n"
             f"Begründung: {reflection.get('explanation', '')}\n"
             f"[Logging] {log_entry}"

--- a/logs/logger.py
+++ b/logs/logger.py
@@ -1,0 +1,44 @@
+"""Structured cycle logging for MetaboMind."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+
+class MetaboLogger:
+    """Append JSON lines with cycle information to a log file."""
+
+    def __init__(self, filepath: str = "logs/metabo_log.jsonl") -> None:
+        self.filepath = Path(filepath)
+        self.filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    def log_cycle(
+        self,
+        *,
+        input_text: str,
+        reflection: str,
+        triplets: List[Tuple[str, str, str]],
+        ent_before: float,
+        ent_after: float,
+        emotion: str,
+        intensity: str,
+    ) -> None:
+        """Write one cycle entry in JSON Lines format."""
+        delta = ent_after - ent_before
+        record = {
+            "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+            "input_text": input_text,
+            "reflection": reflection,
+            "triplets": [list(t) for t in triplets],
+            "entropy_before": ent_before,
+            "entropy_after": ent_after,
+            "delta": delta,
+            "emotion": emotion,
+            "intensity": intensity,
+        }
+        with self.filepath.open("a", encoding="utf-8", newline="\n") as fh:
+            json.dump(record, fh, ensure_ascii=False)
+            fh.write("\n")
+

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 from control.cycle_manager import CycleManager
+from logs.logger import MetaboLogger
 from metabo_rules import METABO_RULES
 
 
 def main():
     print(METABO_RULES)
-    manager = CycleManager()
+    manager = CycleManager(logger=MetaboLogger())
     text = input("Eingabe: ")
     result = manager.run_cycle(text)
     print(result)

--- a/triplet_parser_llm.py
+++ b/triplet_parser_llm.py
@@ -1,0 +1,124 @@
+"""LLM-based extraction of semantic triples from German text."""
+from __future__ import annotations
+
+import json
+import ast
+import os
+import logging
+from typing import List, Tuple
+
+import openai
+
+# System prompt instructing the model
+
+_SYSTEM_PROMPT = (
+    "Extrahiere aus folgendem deutschen Text alle bedeutungsvollen Aussagen als "
+    "Tripel (Subjekt, Prädikat, Objekt). "
+    "Gib nur eine Liste von Tripeln im Format [('Subjekt', 'Prädikat', 'Objekt')] "
+    "zurück. Kein Kommentar, keine Erklärungen."
+)
+logger = logging.getLogger(__name__)
+
+
+def _parse_unquoted(text: str) -> List[Tuple[str, str, str]] | None:
+    """Attempt to parse a list of triples without quoted strings."""
+    import re
+
+    txt = text.strip()
+    if not (txt.startswith("[") and txt.endswith("]")):
+        return None
+    inner = txt[1:-1].strip()
+    # split triples separated by '],[' or '),(' etc.
+    segments = re.split(r"\]\s*,\s*\[|\)\s*,\s*\(|\],\s*\(|\),\s*\[", inner)
+    triples: List[Tuple[str, str, str]] = []
+    for seg in segments:
+        seg = seg.strip().strip("[]()")
+        parts = [p.strip(" '\"") for p in seg.split(',')]
+        if len(parts) != 3:
+            return None
+        triples.append(tuple(parts))
+    return triples
+
+
+def _parse_response(content: str) -> List[Tuple[str, str, str]] | None:
+    """Parse a raw string from the LLM into a list of triples."""
+    text = content.strip()
+    if text.startswith("```") and text.endswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3:
+            text = "\n".join(lines[1:-1])
+    # Try JSON first, then Python literal evaluation
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            data = ast.literal_eval(text)
+        except Exception:
+            import re
+
+            match = re.search(r"\[.*\]", text, re.S)
+            if match:
+                snippet = match.group(0)
+                for parser in (json.loads, ast.literal_eval):
+                    try:
+                        data = parser(snippet)
+                        break
+                    except Exception:
+                        data = None
+                if data is None:
+                    data = _parse_unquoted(snippet)
+            else:
+                data = _parse_unquoted(text)
+            if data is None:
+                return None
+    if isinstance(data, list):
+        triples: List[Tuple[str, str, str]] = []
+        for item in data:
+            if (
+                isinstance(item, (list, tuple))
+                and len(item) == 3
+            ):
+                triples.append(
+                    (str(item[0]).strip(), str(item[1]).strip(), str(item[2]).strip())
+                )
+        return triples
+    return None
+
+
+def extract_triplets_via_llm(text: str, model: str = "gpt-3.5-turbo") -> List[Tuple[str, str, str]]:
+    """Extract semantic triples from ``text`` using an OpenAI chat model."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.error("No OpenAI API key provided")
+        return []
+
+    client = openai.OpenAI(api_key=api_key)
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            temperature=0,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": text},
+            ],
+        )
+    except Exception as exc:
+        logger.error("LLM request failed: %s", exc)
+        return []
+
+    try:
+        content = response.choices[0].message.content
+    except Exception:
+        # Fallback for older client versions
+        content = response["choices"][0]["message"]["content"]
+    triples = _parse_response(content)
+    if triples is None:
+        logger.error("Parsing failed. Text: %r Response: %r", text, content)
+        return []
+    return triples
+
+
+if __name__ == "__main__":
+    example = "Freiheit ist wie ein Schmetterling – je mehr du sie jagst, desto weiter fliegt sie."
+    print(extract_triplets_via_llm(example))


### PR DESCRIPTION
## Summary
- instantiate `MetaboLogger` in main for default cycle logging
- keep `MetaboLogger` implementation for JSONL logs
- integrate with `CycleManager`

## Testing
- `python3 -m py_compile triplet_parser_llm.py control/cycle_manager.py logs/logger.py main.py`
- `python3 triplet_parser_llm.py` *(fails: No OpenAI API key provided)*
- `python3 main.py <<'EOF'
A B C
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686c233f59ac832e96b5462f38997e41