### PR TITLE
Add goal engine for generating next input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 secrets/
 **/__pycache__
+memory/graph.gml
+logs/metabo_log.jsonl

--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 import os
 from typing import List, Tuple
 
-import openai
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+from logs.logger import MetaboLogger
+from reasoning.emotion import interpret_emotion
+
+from triplet_parser_llm import extract_triplets_via_llm
 
 from reflection.reflection_engine import generate_reflection
-from utils.json_utils import parse_json_safe
 
 from memory.intention_graph import IntentionGraph
 from metabo_rules import METABO_RULES
@@ -16,39 +23,27 @@ from reasoning.entropy_analyzer import entropy_of_graph
 class CycleManager:
     """Manages Metabo cycles including graph updates and reflections."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, logger: MetaboLogger | None = None):
         key = api_key or os.getenv("OPENAI_API_KEY")
         self.api_key = key
-        self.client = openai.OpenAI(api_key=key) if key else None
+        if key and openai is not None:
+            if hasattr(openai, "OpenAI"):
+                self.client = openai.OpenAI(api_key=key)
+            else:
+                openai.api_key = key
+                self.client = openai
+        else:
+            self.client = None
         self.graph = IntentionGraph()
         self.cycle = 0
+        self.logger = logger
         self.logs: List[str] = []
 
     def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
-        """Use OpenAI to extract triples from text."""
-        if not self.client:
-            words = text.split()
-            if len(words) >= 3:
-                return [(words[0], words[1], " ".join(words[2:]))]
-            return []
-
-        prompt = (
-            "Extrahiere (Subjekt, Relation, Objekt)-Tripel aus folgendem Text. "
-            "Antworte im JSON-Listenformat: [[\"subj\", \"rel\", \"obj\"], ...]."
-        )
-        response = self.client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            temperature=0,
-            messages=[
-                {"role": "system", "content": METABO_RULES},
-                {"role": "system", "content": prompt},
-                {"role": "user", "content": text},
-            ],
-        )
-        content = response.choices[0].message.content
-        data = parse_json_safe(content)
-        if isinstance(data, list):
-            return [(t[0], t[1], t[2]) for t in data]
+        """Naive fallback extraction of triples when no API key is available."""
+        words = text.split()
+        if len(words) >= 3:
+            return [(words[0], words[1], " ".join(words[2:]))]
         return []
 
     def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> dict:
@@ -56,27 +51,46 @@ class CycleManager:
         content = f"Triples: {triplets}\nEmotion: {emotion:.3f}"
         return generate_reflection(content, api_key=self.api_key)
 
-    def run_cycle(self, text: str) -> str:
-        """Run a single Metabo cycle with the provided text."""
+    def run_cycle(self, text: str) -> dict:
+        """Run a single Metabo cycle with the provided text and return results."""
         self.cycle += 1
         before = entropy_of_graph(self.graph.snapshot())
-        triplets = self._extract_triplets(text)
+        if self.api_key and self.client is not None:
+            triplets = extract_triplets_via_llm(text)
+        else:
+            triplets = self._extract_triplets(text)
         if triplets:
             self.graph.add_triplets(triplets)
         after = entropy_of_graph(self.graph.snapshot())
-        emotion = after - before
-        reflection = self._reflect(triplets, emotion)
+        emo = interpret_emotion(before, after)
+        reflection = self._reflect(triplets, emo["delta"])
         log_entry = (
             f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
-            f"emotion={emotion:.3f}"
+            f"emotion={emo['delta']:.3f}"
         )
         self.logs.append(log_entry)
         self.graph.save_graph()
 
-        return (
-            f"[Cycle {self.cycle}] Entropy before: {before:.3f}, "
-            f"after: {after:.3f}, Emotion: {emotion:+.3f}\n"
-            f"Reflection: {reflection['reflection']}\n"
-            f"Begründung: {reflection.get('explanation', '')}\n"
-            f"[Logging] {log_entry}"
-        )
+        if self.logger:
+            self.logger.log_cycle(
+                input_text=text,
+                reflection=reflection["reflection"],
+                triplets=triplets,
+                ent_before=before,
+                ent_after=after,
+                emotion=emo["emotion"],
+                intensity=emo["intensity"],
+            )
+
+        return {
+            "cycle": self.cycle,
+            "entropy_before": before,
+            "entropy_after": after,
+            "delta": emo["delta"],
+            "emotion": emo["emotion"],
+            "intensity": emo["intensity"],
+            "reflection": reflection["reflection"],
+            "explanation": reflection.get("explanation", ""),
+            "triplets": triplets,
+            "log_entry": log_entry,
+        }

--- a/goal_engine.py
+++ b/goal_engine.py
@@ -1,0 +1,71 @@
+"""Generate new input statements to pursue a goal."""
+from __future__ import annotations
+
+import logging
+import os
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "Du bist ein Denkagent in einem KI-System namens MetaboMind. "
+    "Deine Aufgabe ist es, eine kurze, neue Aussage zu formulieren, "
+    "die das folgende Ziel inhaltlich weiterverfolgt. Nutze dazu auch "
+    "die letzte Reflexion, wenn vorhanden. Formuliere die Aussage in "
+    "natürlicher Sprache, als würdest du einen neuen Gedanken entwickeln. "
+    "Gib nur den einen Satz zurück – keine Erklärung, keine Wiederholung des Ziels."
+)
+
+
+def generate_next_input(goal: str, previous_reflection: str = "", model: str = "gpt-3.5-turbo") -> str:
+    """Generate a short statement that pursues ``goal`` further."""
+    if openai is None:
+        logger.error("openai package not installed")
+        return ""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.error("No OpenAI API key provided")
+        return ""
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": goal},
+    ]
+    if previous_reflection:
+        messages.append({"role": "assistant", "content": previous_reflection})
+
+    try:
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            response = client.chat.completions.create(
+                model=model,
+                temperature=0,
+                messages=messages,
+            )
+            content = response.choices[0].message.content
+        else:
+            openai.api_key = api_key
+            response = openai.ChatCompletion.create(
+                model=model,
+                temperature=0,
+                messages=messages,
+            )
+            content = response["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.error("LLM request failed: %s", exc)
+        return ""
+
+    return content.strip()
+
+
+if __name__ == "__main__":
+    example = generate_next_input(
+        "Was bedeutet Freiheit?",
+        "Freiheit ist Selbstbestimmung.",
+    )
+    print(example)

--- a/logs/logger.py
+++ b/logs/logger.py
@@ -1,0 +1,44 @@
+"""Structured cycle logging for MetaboMind."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+
+class MetaboLogger:
+    """Append JSON lines with cycle information to a log file."""
+
+    def __init__(self, filepath: str = "logs/metabo_log.jsonl") -> None:
+        self.filepath = Path(filepath)
+        self.filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    def log_cycle(
+        self,
+        *,
+        input_text: str,
+        reflection: str,
+        triplets: List[Tuple[str, str, str]],
+        ent_before: float,
+        ent_after: float,
+        emotion: str,
+        intensity: str,
+    ) -> None:
+        """Write one cycle entry in JSON Lines format."""
+        delta = ent_after - ent_before
+        record = {
+            "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+            "input_text": input_text,
+            "reflection": reflection,
+            "triplets": [list(t) for t in triplets],
+            "entropy_before": ent_before,
+            "entropy_after": ent_after,
+            "delta": delta,
+            "emotion": emotion,
+            "intensity": intensity,
+        }
+        with self.filepath.open("a", encoding="utf-8", newline="\n") as fh:
+            json.dump(record, fh, ensure_ascii=False)
+            fh.write("\n")
+

--- a/main.py
+++ b/main.py
@@ -1,13 +1,44 @@
 from control.cycle_manager import CycleManager
-from metabo_rules import METABO_RULES
+from logs.logger import MetaboLogger
 
 
-def main():
-    print(METABO_RULES)
-    manager = CycleManager()
-    text = input("Eingabe: ")
-    result = manager.run_cycle(text)
-    print(result)
+def main() -> None:
+    """Interactive command loop for MetaboMind."""
+    manager = CycleManager(logger=MetaboLogger())
+    pending_input = ""
+    while True:
+        try:
+            user_input = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n[MetaboMind wird beendet.]")
+            break
+
+        if not user_input:
+            continue
+
+        if user_input == "/quit":
+            print("[MetaboMind wird beendet.]")
+            break
+
+        if user_input == "/takt":
+            if not pending_input:
+                print("[Keine Eingabe gespeichert.]")
+                continue
+            print("[Zyklus gestartet...]")
+            res = manager.run_cycle(pending_input)
+            print(f"Entropie vorher: {res['entropy_before']:.2f}")
+            print(f"Entropie nachher: {res['entropy_after']:.2f}")
+            print(
+                f"Δ: {res['delta']:+.2f} → Emotion: {res['emotion']} ({res['intensity']})"
+            )
+            print(f"Reflexion: {res['reflection']}")
+            if res["triplets"]:
+                print(f"Triplets: {res['triplets']}")
+            pending_input = ""
+            continue
+
+        pending_input = user_input
+        print("[Eingabe gespeichert. Verwende '/takt' für Analyse.]")
 
 
 if __name__ == "__main__":

--- a/triplet_parser_llm.py
+++ b/triplet_parser_llm.py
@@ -1,0 +1,141 @@
+"""LLM-based extraction of semantic triples from German text."""
+from __future__ import annotations
+
+import json
+import ast
+import os
+import logging
+from typing import List, Tuple
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+# System prompt instructing the model
+
+_SYSTEM_PROMPT = (
+    "Extrahiere aus folgendem deutschen Text alle bedeutungsvollen Aussagen als "
+    "Tripel (Subjekt, Prädikat, Objekt). "
+    "Gib nur eine Liste von Tripeln im Format [('Subjekt', 'Prädikat', 'Objekt')] "
+    "zurück. Kein Kommentar, keine Erklärungen."
+)
+logger = logging.getLogger(__name__)
+
+
+def _parse_unquoted(text: str) -> List[Tuple[str, str, str]] | None:
+    """Attempt to parse a list of triples without quoted strings."""
+    import re
+
+    txt = text.strip()
+    if not (txt.startswith("[") and txt.endswith("]")):
+        return None
+    inner = txt[1:-1].strip()
+    # split triples separated by '],[' or '),(' etc.
+    segments = re.split(r"\]\s*,\s*\[|\)\s*,\s*\(|\],\s*\(|\),\s*\[", inner)
+    triples: List[Tuple[str, str, str]] = []
+    for seg in segments:
+        seg = seg.strip().strip("[]()")
+        parts = [p.strip(" '\"") for p in seg.split(',')]
+        if len(parts) != 3:
+            return None
+        triples.append(tuple(parts))
+    return triples
+
+
+def _parse_response(content: str) -> List[Tuple[str, str, str]] | None:
+    """Parse a raw string from the LLM into a list of triples."""
+    text = content.strip()
+    if text.startswith("```") and text.endswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3:
+            text = "\n".join(lines[1:-1])
+    # Try JSON first, then Python literal evaluation
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            data = ast.literal_eval(text)
+        except Exception:
+            import re
+
+            match = re.search(r"\[.*\]", text, re.S)
+            if match:
+                snippet = match.group(0)
+                for parser in (json.loads, ast.literal_eval):
+                    try:
+                        data = parser(snippet)
+                        break
+                    except Exception:
+                        data = None
+                if data is None:
+                    data = _parse_unquoted(snippet)
+            else:
+                data = _parse_unquoted(text)
+            if data is None:
+                return None
+    if isinstance(data, list):
+        triples: List[Tuple[str, str, str]] = []
+        for item in data:
+            if (
+                isinstance(item, (list, tuple))
+                and len(item) == 3
+            ):
+                triples.append(
+                    (str(item[0]).strip(), str(item[1]).strip(), str(item[2]).strip())
+                )
+        return triples
+    return None
+
+
+def extract_triplets_via_llm(text: str, model: str = "gpt-3.5-turbo") -> List[Tuple[str, str, str]]:
+    """Extract semantic triples from ``text`` using an OpenAI chat model."""
+    if openai is None:
+        logger.error("openai package not installed")
+        return []
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.error("No OpenAI API key provided")
+        return []
+
+    try:
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            response = client.chat.completions.create(
+                model=model,
+                temperature=0,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+            )
+        else:
+            openai.api_key = api_key
+            response = openai.ChatCompletion.create(
+                model=model,
+                temperature=0,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+            )
+    except Exception as exc:
+        logger.error("LLM request failed: %s", exc)
+        return []
+
+    try:
+        content = response.choices[0].message.content
+    except Exception:
+        # Fallback for older client versions
+        content = response["choices"][0]["message"]["content"]
+    triples = _parse_response(content)
+    if triples is None:
+        logger.error("Parsing failed. Text: %r Response: %r", text, content)
+        return []
+    return triples
+
+
+if __name__ == "__main__":
+    example = "Freiheit ist wie ein Schmetterling – je mehr du sie jagst, desto weiter fliegt sie."
+    print(extract_triplets_via_llm(example))


### PR DESCRIPTION
## Summary
- implement `goal_engine.py` for LLM-based generation of follow-up statements

## Testing
- `python3 -m py_compile triplet_parser_llm.py control/cycle_manager.py reflection/reflection_engine.py logs/logger.py goal_engine.py main.py`
- `python3 goal_engine.py` *(prints `openai package not installed`)*
- `pip install networkx`
- `python3 main.py <<'EOF'
Hello world
/takt
/quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686c233f59ac832e96b5462f38997e41