### PR TITLE
Add MetaboMind cycle module

### DIFF
--- a/context_selector.py
+++ b/context_selector.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import networkx as nx
+
+
+def load_context(graph: nx.Graph, target_node: str, top_k: int = 5) -> list[str]:
+    """Return up to ``top_k`` neighbor nodes of ``target_node`` as context."""
+    if target_node in graph:
+        neighbors = list(graph.neighbors(target_node))
+        return neighbors[:top_k]
+    return []

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class GoalManager:
+    """Simple file-based goal management."""
+
+    def __init__(self, path: str = "goals/current_goal.txt", reflection_path: str = "goals/last_reflection.txt") -> None:
+        self.goal_path = Path(path)
+        self.goal_path.parent.mkdir(parents=True, exist_ok=True)
+        self.reflection_path = Path(reflection_path)
+        self.reflection_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def get_goal(self) -> str:
+        """Return the current goal or empty string if none exists."""
+        try:
+            return self.goal_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    def set_goal(self, goal: str) -> None:
+        """Persist ``goal`` for later retrieval."""
+        self.goal_path.write_text(goal, encoding="utf-8")
+
+    def load_reflection(self) -> str:
+        """Return the last reflection text if available."""
+        try:
+            return self.reflection_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    def save_reflection(self, reflection: str) -> None:
+        """Store the most recent reflection text."""
+        self.reflection_path.write_text(reflection, encoding="utf-8")

--- a/graph_manager.py
+++ b/graph_manager.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from memory.intention_graph import IntentionGraph
+
+
+class GraphManager:
+    """Lightweight wrapper for ``IntentionGraph`` access."""
+
+    def __init__(self, filepath: str = "memory/graph.gml") -> None:
+        self.intention_graph = IntentionGraph(filepath)
+
+    def snapshot(self):
+        return self.intention_graph.snapshot()
+
+    def add_triplets(self, triplets) -> None:
+        self.intention_graph.add_triplets(triplets)
+
+    def save(self) -> None:
+        self.intention_graph.save_graph()
+
+    @property
+    def graph(self):
+        return self.intention_graph.graph

--- a/metabo_cycle.py
+++ b/metabo_cycle.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from goal_manager import GoalManager
+from graph_manager import GraphManager
+from context_selector import load_context
+from triplet_parser_llm import extract_triplets_via_llm
+from reflection.reflection_engine import generate_reflection
+from logs.logger import MetaboLogger
+from reasoning.emotion import interpret_emotion
+from reasoning.entropy_analyzer import entropy_of_graph
+
+logger = logging.getLogger(__name__)
+
+
+def run_metabo_cycle(user_input: str) -> Dict[str, object]:
+    """Execute one MetaboMind cycle and return a structured result."""
+    goal_mgr = GoalManager()
+    graph_mgr = GraphManager()
+    log = MetaboLogger()
+
+    goal = goal_mgr.get_goal()
+    last_reflection = goal_mgr.load_reflection()
+
+    graph_snapshot = graph_mgr.snapshot()
+    entropy_before = entropy_of_graph(graph_snapshot)
+
+    try:
+        context_nodes = load_context(graph_mgr.graph, goal)
+    except Exception as exc:
+        logger.warning("context selection failed: %s", exc)
+        context_nodes = []
+
+    prompt = (
+        f"Ziel: {goal}\n"\
+        f"Eingabe: {user_input}\n"\
+        f"Kontext: {', '.join(context_nodes)}\n"\
+        f"Letzte Reflexion: {last_reflection}"
+    )
+
+    try:
+        reflection_data = generate_reflection(prompt)
+        reflection_text = reflection_data.get("reflection", "")
+    except Exception as exc:
+        logger.warning("reflection generation failed: %s", exc)
+        reflection_text = ""
+        reflection_data = {"reflection": "", "triplets": [], "explanation": ""}
+
+    try:
+        triplets = extract_triplets_via_llm(reflection_text)
+    except Exception as exc:
+        logger.warning("triplet extraction failed: %s", exc)
+        triplets = []
+
+    if triplets:
+        try:
+            graph_mgr.add_triplets(triplets)
+        except Exception as exc:
+            logger.warning("graph update failed: %s", exc)
+
+    entropy_after = entropy_of_graph(graph_mgr.snapshot())
+    emotion = interpret_emotion(entropy_before, entropy_after)
+
+    try:
+        graph_mgr.save()
+    except Exception as exc:
+        logger.warning("graph save failed: %s", exc)
+
+    try:
+        log.log_cycle(
+            input_text=user_input,
+            reflection=reflection_text,
+            triplets=triplets,
+            ent_before=entropy_before,
+            ent_after=entropy_after,
+            emotion=emotion["emotion"],
+            intensity=emotion["intensity"],
+        )
+    except Exception as exc:
+        logger.warning("logging failed: %s", exc)
+
+    goal_mgr.save_reflection(reflection_text)
+
+    return {
+        "goal": goal,
+        "input": user_input,
+        "context": context_nodes,
+        "reflection": reflection_text,
+        "triplets": triplets,
+        "entropy_before": entropy_before,
+        "entropy_after": entropy_after,
+        "emotion": emotion["emotion"],
+        "delta": emotion["delta"],
+    }

--- a/tests/test_goal_engine.py
+++ b/tests/test_goal_engine.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import goal_engine
+
+
+def test_missing_openai(monkeypatch):
+    monkeypatch.setattr(goal_engine, "openai", None)
+    with pytest.raises(ImportError):
+        goal_engine.generate_next_input("Test")
+
+
+def test_missing_api_key(monkeypatch):
+    dummy = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: None))
+    monkeypatch.setattr(goal_engine, "openai", dummy)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(EnvironmentError):
+        goal_engine.generate_next_input("Test")
+
+
+def test_fallback_default(monkeypatch):
+    dummy = types.SimpleNamespace()
+    def create(model, temperature, messages):
+        return {"choices": [{"message": {"content": ""}}]}
+    dummy.ChatCompletion = types.SimpleNamespace(create=create)
+    monkeypatch.setattr(goal_engine, "openai", dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    out = goal_engine.generate_next_input("Goal")
+    assert out == "Verantwortung ist der Preis der Freiheit."


### PR DESCRIPTION
## Summary
- add simple GoalManager for file-based goal persistence
- create GraphManager wrapper around IntentionGraph
- implement context node loader
- introduce `run_metabo_cycle` orchestrating a full cycle

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c495d7fa0832e92aa5e4824793e55