### PR TITLE
Add robust triplet extraction helper

### DIFF
--- a/context_selector.py
+++ b/context_selector.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import networkx as nx
+
+
+def load_context(graph: nx.Graph, target_node: str, top_k: int = 5) -> list[str]:
+    """Return up to ``top_k`` neighbor nodes of ``target_node`` as context."""
+    if target_node in graph:
+        neighbors = list(graph.neighbors(target_node))
+        return neighbors[:top_k]
+    return []

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class GoalManager:
+    """Simple file-based goal management."""
+
+    def __init__(self, path: str = "goals/current_goal.txt", reflection_path: str = "goals/last_reflection.txt") -> None:
+        self.goal_path = Path(path)
+        self.goal_path.parent.mkdir(parents=True, exist_ok=True)
+        self.reflection_path = Path(reflection_path)
+        self.reflection_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def get_goal(self) -> str:
+        """Return the current goal or empty string if none exists."""
+        try:
+            return self.goal_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    def set_goal(self, goal: str) -> None:
+        """Persist ``goal`` for later retrieval."""
+        self.goal_path.write_text(goal, encoding="utf-8")
+
+    def load_reflection(self) -> str:
+        """Return the last reflection text if available."""
+        try:
+            return self.reflection_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    def save_reflection(self, reflection: str) -> None:
+        """Store the most recent reflection text."""
+        self.reflection_path.write_text(reflection, encoding="utf-8")
+
+
+_DEFAULT_MANAGER = GoalManager()
+
+
+def set_goal(goal: str) -> None:
+    """Convenience wrapper to store ``goal`` using the default manager."""
+    _DEFAULT_MANAGER.set_goal(goal)
+
+
+def get_active_goal() -> str:
+    """Return the currently active goal using the default manager."""
+    return _DEFAULT_MANAGER.get_goal()
+
+
+def load_last_reflection() -> str:
+    """Return the last saved reflection."""
+    return _DEFAULT_MANAGER.load_reflection()
+
+
+def save_last_reflection(text: str) -> None:
+    """Persist ``text`` as the latest reflection."""
+    _DEFAULT_MANAGER.save_reflection(text)

--- a/graph_manager.py
+++ b/graph_manager.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from memory.intention_graph import IntentionGraph
+
+
+class GraphManager:
+    """Lightweight wrapper for ``IntentionGraph`` access."""
+
+    def __init__(self, filepath: str = "memory/graph.gml") -> None:
+        self.intention_graph = IntentionGraph(filepath)
+
+    def snapshot(self):
+        return self.intention_graph.snapshot()
+
+    def add_triplets(self, triplets) -> None:
+        self.intention_graph.add_triplets(triplets)
+
+    def save(self) -> None:
+        self.intention_graph.save_graph()
+
+    @property
+    def graph(self):
+        return self.intention_graph.graph

--- a/main.py
+++ b/main.py
@@ -1,11 +1,21 @@
-from control.cycle_manager import CycleManager
-from logs.logger import MetaboLogger
+"""Command-line interface for MetaboMind."""
+from __future__ import annotations
+
+from metabo_cycle import run_metabo_cycle
+from goal_manager import set_goal, get_active_goal
+
+
+def print_help() -> None:
+    """Display available CLI commands."""
+    print("Verfügbare Befehle:")
+    print("/quit  - Programm beenden")
+    print("/ziel <Text> - neues Ziel setzen")
+    print("/hilfe - diese Hilfe anzeigen")
 
 
 def main() -> None:
-    """Interactive command loop for MetaboMind."""
-    manager = CycleManager(logger=MetaboLogger())
-    pending_input = ""
+    """Interactive loop processing user input via ``run_metabo_cycle``."""
+    print("[MetaboMind CLI]")
     while True:
         try:
             user_input = input("> ").strip()
@@ -19,26 +29,25 @@ def main() -> None:
         if user_input == "/quit":
             print("[MetaboMind wird beendet.]")
             break
-
-        if user_input == "/takt":
-            if not pending_input:
-                print("[Keine Eingabe gespeichert.]")
-                continue
-            print("[Zyklus gestartet...]")
-            res = manager.run_cycle(pending_input)
-            print(f"Entropie vorher: {res['entropy_before']:.2f}")
-            print(f"Entropie nachher: {res['entropy_after']:.2f}")
-            print(
-                f"Δ: {res['delta']:+.2f} → Emotion: {res['emotion']} ({res['intensity']})"
-            )
-            print(f"Reflexion: {res['reflection']}")
-            if res["triplets"]:
-                print(f"Triplets: {res['triplets']}")
-            pending_input = ""
+        if user_input == "/hilfe":
+            print_help()
+            continue
+        if user_input.startswith("/ziel"):
+            new_goal = user_input[len("/ziel"):].strip()
+            if not new_goal:
+                print("[Bitte ein Ziel nach '/ziel' angeben.]")
+            else:
+                set_goal(new_goal)
+                print(f"[Neues Ziel gespeichert: {new_goal}]")
             continue
 
-        pending_input = user_input
-        print("[Eingabe gespeichert. Verwende '/takt' für Analyse.]")
+        result = run_metabo_cycle(user_input)
+        print("[Zyklus abgeschlossen]")
+        print(f"Ziel: {result['goal']}")
+        print(f"Antwort: {result['reflection']}")
+        print(f"Emotion: {result['emotion']} (Δ={result['delta']:+.2f})")
+        if result['triplets']:
+            print(f"Neue Tripel: {result['triplets']}")
 
 
 if __name__ == "__main__":

--- a/metabo_cycle.py
+++ b/metabo_cycle.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from goal_manager import GoalManager
+from graph_manager import GraphManager
+from context_selector import load_context
+from triplet_parser_llm import extract_triplets_via_llm
+from reflection.reflection_engine import generate_reflection
+from logs.logger import MetaboLogger
+from reasoning.emotion import interpret_emotion
+from reasoning.entropy_analyzer import entropy_of_graph
+
+logger = logging.getLogger(__name__)
+
+
+def run_metabo_cycle(user_input: str) -> Dict[str, object]:
+    """Execute one MetaboMind cycle and return a structured result."""
+    goal_mgr = GoalManager()
+    graph_mgr = GraphManager()
+    log = MetaboLogger()
+
+    goal = goal_mgr.get_goal()
+    last_reflection = goal_mgr.load_reflection()
+
+    graph_snapshot = graph_mgr.snapshot()
+    entropy_before = entropy_of_graph(graph_snapshot)
+
+    try:
+        context_nodes = load_context(graph_mgr.graph, goal)
+    except Exception as exc:
+        logger.warning("context selection failed: %s", exc)
+        context_nodes = []
+
+    prompt = (
+        f"Ziel: {goal}\n"\
+        f"Eingabe: {user_input}\n"\
+        f"Kontext: {', '.join(context_nodes)}\n"\
+        f"Letzte Reflexion: {last_reflection}"
+    )
+
+    try:
+        reflection_data = generate_reflection(prompt)
+        reflection_text = reflection_data.get("reflection", "")
+    except Exception as exc:
+        logger.warning("reflection generation failed: %s", exc)
+        reflection_text = ""
+        reflection_data = {"reflection": "", "triplets": [], "explanation": ""}
+
+    try:
+        triplets = extract_triplets_via_llm(reflection_text)
+    except Exception as exc:
+        logger.warning("triplet extraction failed: %s", exc)
+        triplets = []
+
+    if triplets:
+        try:
+            graph_mgr.add_triplets(triplets)
+        except Exception as exc:
+            logger.warning("graph update failed: %s", exc)
+
+    entropy_after = entropy_of_graph(graph_mgr.snapshot())
+    emotion = interpret_emotion(entropy_before, entropy_after)
+
+    try:
+        graph_mgr.save()
+    except Exception as exc:
+        logger.warning("graph save failed: %s", exc)
+
+    try:
+        log.log_cycle(
+            input_text=user_input,
+            reflection=reflection_text,
+            triplets=triplets,
+            ent_before=entropy_before,
+            ent_after=entropy_after,
+            emotion=emotion["emotion"],
+            intensity=emotion["intensity"],
+        )
+    except Exception as exc:
+        logger.warning("logging failed: %s", exc)
+
+    goal_mgr.save_reflection(reflection_text)
+
+    return {
+        "goal": goal,
+        "input": user_input,
+        "context": context_nodes,
+        "reflection": reflection_text,
+        "triplets": triplets,
+        "entropy_before": entropy_before,
+        "entropy_after": entropy_after,
+        "emotion": emotion["emotion"],
+        "delta": emotion["delta"],
+    }

--- a/recall_context.py
+++ b/recall_context.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import List, Dict
+import networkx as nx
+
+from memory.intention_graph import IntentionGraph
+from goal_manager import get_active_goal
+
+
+def _edges_to_dicts(edges: List[tuple]) -> List[Dict[str, str]]:
+    """Convert edges with data to list of triple dictionaries."""
+    out: List[Dict[str, str]] = []
+    for subj, obj, data in edges:
+        rel = ""
+        if isinstance(data, dict):
+            rel = str(data.get("relation", ""))
+        out.append({"subject": subj, "predicate": rel, "object": obj})
+    return out
+
+
+def recall_context(limit: int = 10, scope: str = "global") -> List[Dict[str, str]]:
+    """Return up to ``limit`` facts from the IntentionGraph.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of triples to return.
+    scope:
+        "goal" focuses on edges connected to the current active goal. Any other
+        value returns a global selection of edges ordered by node degree.
+    """
+
+    ig = IntentionGraph()
+    G: nx.MultiDiGraph = ig.graph
+
+    edges: List[tuple] = []
+    if scope == "goal":
+        target = get_active_goal()
+        if target and target in G:
+            edges.extend(G.out_edges(target, data=True))
+            edges.extend(G.in_edges(target, data=True))
+
+    if not edges:
+        # Fallback to global view sorted by node degree
+        ranked_nodes = sorted(G.degree(), key=lambda x: x[1], reverse=True)
+        for node, _ in ranked_nodes:
+            for _, neighbor, data in G.edges(node, data=True):
+                edges.append((node, neighbor, data))
+                if len(edges) >= limit:
+                    break
+            if len(edges) >= limit:
+                break
+
+    return _edges_to_dicts(edges[:limit])

--- a/reflection/reflection_engine.py
+++ b/reflection/reflection_engine.py
@@ -39,9 +39,15 @@ def generate_reflection(text: str, api_key: str | None = None) -> Dict[str, obje
 
     system_prompt = (
         METABO_RULES
-        + "\nReflektiere die folgende Aussage, verbessere oder präzisiere sie. "
-        "Antworte im JSON-Format mit den Schlüsseln 'reflection', 'explanation' "
-        "und optional 'triplets' als Liste von [subj, pred, obj]."
+        + (
+            "\nDu bist ein Denkagent in einem KI-System namens MetaboMind. "
+            "Deine Aufgabe ist es, auf eine Nutzereingabe im Kontext eines Ziels "
+            "zu antworten. Sprich dabei direkt zum Nutzer – nicht über die Eingabe. "
+            "Formuliere eine neue Aussage, die dem Ziel näherkommt. Nutze dein "
+            "vorhandenes Wissen und die letzte Reflexion, wenn sie dir hilft. "
+            "Antworte in einem einzigen natürlichen Satz. Keine Meta-Analyse, "
+            "keine Wiederholung des Ziels."
+        )
     )
 
     if hasattr(openai, "OpenAI"):

--- a/tests/test_goal_engine.py
+++ b/tests/test_goal_engine.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import goal_engine
+
+
+def test_missing_openai(monkeypatch):
+    monkeypatch.setattr(goal_engine, "openai", None)
+    with pytest.raises(ImportError):
+        goal_engine.generate_next_input("Test")
+
+
+def test_missing_api_key(monkeypatch):
+    dummy = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: None))
+    monkeypatch.setattr(goal_engine, "openai", dummy)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(EnvironmentError):
+        goal_engine.generate_next_input("Test")
+
+
+def test_fallback_default(monkeypatch):
+    dummy = types.SimpleNamespace()
+    def create(model, temperature, messages):
+        return {"choices": [{"message": {"content": ""}}]}
+    dummy.ChatCompletion = types.SimpleNamespace(create=create)
+    monkeypatch.setattr(goal_engine, "openai", dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    out = goal_engine.generate_next_input("Goal")
+    assert out == "Verantwortung ist der Preis der Freiheit."

--- a/tests/test_recall_context.py
+++ b/tests/test_recall_context.py
@@ -1,0 +1,39 @@
+import networkx as nx
+import recall_context
+
+
+def test_recall_context_global(monkeypatch):
+    G = nx.MultiDiGraph()
+    G.add_edge("A", "B", relation="ab")
+    G.add_edge("B", "C", relation="bc")
+
+    class DummyIG:
+        def __init__(self, path="x"):
+            self.graph = G
+
+    monkeypatch.setattr(recall_context, "IntentionGraph", DummyIG)
+    res = recall_context.recall_context(limit=2)
+    assert {
+        (d["subject"], d["predicate"], d["object"]) for d in res
+    } == {
+        ("A", "ab", "B"),
+        ("B", "bc", "C"),
+    }
+
+
+def test_recall_context_goal(monkeypatch):
+    G = nx.MultiDiGraph()
+    G.add_edge("goal", "X", relation="r1")
+    G.add_edge("Y", "goal", relation="r2")
+
+    class DummyIG:
+        def __init__(self, path="x"):
+            self.graph = G
+
+    monkeypatch.setattr(recall_context, "IntentionGraph", DummyIG)
+    monkeypatch.setattr(recall_context, "get_active_goal", lambda: "goal")
+    res = recall_context.recall_context(scope="goal")
+    assert {tuple(d.values())[:3] for d in res} == {
+        ("goal", "r1", "X"),
+        ("Y", "r2", "goal"),
+    }

--- a/tests/test_triplet_extractor.py
+++ b/tests/test_triplet_extractor.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import logging
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import triplet_extractor
+
+
+def test_duplicate_removal(caplog):
+    text = str([('du', 'kannst', 'es')] * 13)
+    with caplog.at_level(logging.INFO):
+        triples = triplet_extractor.extract_triplets(text)
+    assert triples == [('du', 'kannst', 'es')]
+    assert any('Duplikate entfernt' in m.message for m in caplog.records)
+
+
+def test_limit_results(caplog):
+    data = [ (str(i), 'ist', 'x') for i in range(12) ]
+    text = str(data)
+    with caplog.at_level(logging.INFO):
+        triples = triplet_extractor.extract_triplets(text)
+    assert len(triples) == 10
+    assert triples == data[:10]
+    assert any('limiting to' in m.message for m in caplog.records)
+
+
+def test_invalid_input(caplog):
+    with caplog.at_level(logging.INFO):
+        triples = triplet_extractor.extract_triplets('nonsense')
+    assert triples == []
+    assert any('No triplets extracted' in m.message for m in caplog.records)

--- a/tests/test_triplet_parser.py
+++ b/tests/test_triplet_parser.py
@@ -1,0 +1,15 @@
+import triplet_parser_llm
+
+
+def test_parse_newline_brackets():
+    content = (
+        "[Es, bedeutet, ständig neue Informationen zu integrieren]\n"
+        "[Es, bedeutet, bestehende Verknüpfungen zu überdenken]\n"
+        "[Es, bedeutet, durch Reflexion und Anpassung an neue Herausforderungen zu wachsen]"
+    )
+    triples = triplet_parser_llm._parse_response(content)
+    assert triples == [
+        ("Es", "bedeutet", "ständig neue Informationen zu integrieren"),
+        ("Es", "bedeutet", "bestehende Verknüpfungen zu überdenken"),
+        ("Es", "bedeutet", "durch Reflexion und Anpassung an neue Herausforderungen zu wachsen"),
+    ]

--- a/triplet_extractor.py
+++ b/triplet_extractor.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+import logging
+
+from triplet_parser_llm import _parse_response
+
+logger = logging.getLogger(__name__)
+
+
+def extract_triplets(text: str, max_triplets: int = 10, debug: bool = False) -> List[Tuple[str, str, str]]:
+    """Extract and clean triples from ``text``.
+
+    Parameters
+    ----------
+    text:
+        Raw output from the LLM containing triples.
+    max_triplets:
+        Maximum number of triples to return.
+    debug:
+        If ``True``, print triples before and after filtering.
+    """
+    triples = _parse_response(text) or []
+    if debug:
+        print("[debug] raw:", triples)
+
+    if not triples:
+        logger.info("No triplets extracted.")
+        return []
+
+    # detect consecutive repetition of the same triple
+    repeat_count = 1
+    warned = False
+    for i in range(1, len(triples)):
+        if triples[i] == triples[i - 1]:
+            repeat_count += 1
+            if repeat_count > 3 and not warned:
+                logger.warning("[TripletExtractor] repeated triple: %r", triples[i])
+                warned = True
+        else:
+            repeat_count = 1
+
+    # remove duplicates while preserving order
+    unique = list(dict.fromkeys(triples))
+    if len(unique) != len(triples):
+        logger.info("[TripletExtractor] Duplikate entfernt (%d → %d)", len(triples), len(unique))
+    triples = unique
+
+    if len(triples) > max_triplets:
+        logger.info("[TripletExtractor] limiting to %d triplets", max_triplets)
+        triples = triples[:max_triplets]
+
+    if debug:
+        print("[debug] filtered:", triples)
+
+    return triples

--- a/triplet_parser_llm.py
+++ b/triplet_parser_llm.py
@@ -31,11 +31,13 @@ def _parse_unquoted(text: str) -> List[Tuple[str, str, str]] | None:
     if not (txt.startswith("[") and txt.endswith("]")):
         return None
     inner = txt[1:-1].strip()
-    # split triples separated by '],[' or '),(' etc.
-    segments = re.split(r"\]\s*,\s*\[|\)\s*,\s*\(|\],\s*\(|\),\s*\[", inner)
+    # split triples separated by brackets, parentheses, commas or newlines
+    segments = re.split(r"\]\s*,\s*\[|\]\s*\n\s*\[|\)\s*,\s*\(|\],\s*\(|\),\s*\[", inner)
     triples: List[Tuple[str, str, str]] = []
     for seg in segments:
         seg = seg.strip().strip("[]()")
+        if not seg:
+            continue
         parts = [p.strip(" '\"") for p in seg.split(',')]
         if len(parts) != 3:
             return None


### PR DESCRIPTION
## Summary
- implement `extract_triplets` to filter duplicates and limit result length
- test the helper for duplicate removal, limit, and invalid input handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c495d7fa0832e92aa5e4824793e55