### PR TITLE
Improve reflection prompt

### DIFF
--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -46,10 +46,20 @@ class CycleManager:
             return [(words[0], words[1], " ".join(words[2:]))]
         return []
 
-    def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> dict:
+    def _reflect(
+        self,
+        user_input: str,
+        triplets: List[Tuple[str, str, str]],
+        emotion: float,
+    ) -> dict:
         """Use the reflection engine to analyse triplets and emotion."""
-        content = f"Triples: {triplets}\nEmotion: {emotion:.3f}"
-        return generate_reflection(content, api_key=self.api_key)
+        return generate_reflection(
+            last_user_input=user_input,
+            goal="",
+            last_reflection="",
+            triplets=triplets,
+            api_key=self.api_key,
+        )
 
     def run_cycle(self, text: str) -> dict:
         """Run a single Metabo cycle with the provided text and return results."""
@@ -63,7 +73,7 @@ class CycleManager:
             self.graph.add_triplets(triplets)
         after = entropy_of_graph(self.graph.snapshot())
         emo = interpret_emotion(before, after)
-        reflection = self._reflect(triplets, emo["delta"])
+        reflection = self._reflect(text, triplets, emo["delta"])
         log_entry = (
             f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
             f"emotion={emo['delta']:.3f}"

--- a/control/metabo_cycle.py
+++ b/control/metabo_cycle.py
@@ -7,6 +7,7 @@ from goals.goal_manager import GoalManager
 from memory.graph_manager import GraphManager
 from memory.context_selector import load_context
 from parsing.triplet_parser_llm import extract_triplets_via_llm
+from memory.recall_context import recall_context
 from reflection.reflection_engine import generate_reflection
 from logs.logger import MetaboLogger
 from reasoning.emotion import interpret_emotion
@@ -42,15 +43,22 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
         logger.warning("context selection failed: %s", exc)
         context_nodes = []
 
-    prompt = (
-        f"Ziel: {goal}\n"\
-        f"Eingabe: {user_input}\n"\
-        f"Kontext: {', '.join(context_nodes)}\n"\
-        f"Letzte Reflexion: {last_reflection}"
-    )
+    try:
+        mem_facts = recall_context(scope="goal", limit=5)
+        fact_triplets = [
+            (d["subject"], d["predicate"], d["object"]) for d in mem_facts
+        ]
+    except Exception as exc:
+        logger.warning("context recall failed: %s", exc)
+        fact_triplets = []
 
     try:
-        reflection_data = generate_reflection(prompt)
+        reflection_data = generate_reflection(
+            last_user_input=user_input,
+            goal=goal,
+            last_reflection=last_reflection,
+            triplets=fact_triplets,
+        )
         reflection_text = reflection_data.get("reflection", "")
     except Exception as exc:
         logger.warning("reflection generation failed: %s", exc)


### PR DESCRIPTION
## Summary
- rework `generate_reflection` for context-aware answers
- pass user input, goal, last reflection and memory triplets
- update Metabo cycle functions to use new interface
- adjust CycleManager for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea3c3cb90832eb766bfd820c97b64