### PR TITLE
Expand IntentionGraph with goal transitions

### DIFF
--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from goals.goal_updater import (
+    propose_goal,
+    check_goal_shift,
+    apply_goal_shift,
+)
 
 from logs.logger import MetaboLogger
 from reasoning.emotion import interpret_emotion
@@ -14,9 +15,9 @@ from reasoning.emotion import interpret_emotion
 from parsing.triplet_parser_llm import extract_triplets_via_llm
 
 from reflection.reflection_engine import generate_reflection
+from goals.goal_manager import GoalManager
 
 from memory.intention_graph import IntentionGraph
-from control.metabo_rules import METABO_RULES
 from reasoning.entropy_analyzer import entropy_of_graph
 
 
@@ -24,20 +25,14 @@ class CycleManager:
     """Manages Metabo cycles including graph updates and reflections."""
 
     def __init__(self, api_key: str | None = None, logger: MetaboLogger | None = None):
-        key = api_key or os.getenv("OPENAI_API_KEY")
-        self.api_key = key
-        if key and openai is not None:
-            if hasattr(openai, "OpenAI"):
-                self.client = openai.OpenAI(api_key=key)
-            else:
-                openai.api_key = key
-                self.client = openai
-        else:
-            self.client = None
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.graph = IntentionGraph()
         self.cycle = 0
         self.logger = logger
         self.logs: List[str] = []
+        self.goal_mgr = GoalManager()
+        self.current_goal = self.goal_mgr.get_goal()
+
 
     def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
         """Naive fallback extraction of triples when no API key is available."""
@@ -46,16 +41,37 @@ class CycleManager:
             return [(words[0], words[1], " ".join(words[2:]))]
         return []
 
-    def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> dict:
+    def _reflect(
+        self,
+        user_input: str,
+        triplets: List[Tuple[str, str, str]],
+        emotion: float,
+    ) -> dict:
         """Use the reflection engine to analyse triplets and emotion."""
-        content = f"Triples: {triplets}\nEmotion: {emotion:.3f}"
-        return generate_reflection(content, api_key=self.api_key)
+        return generate_reflection(
+            last_user_input=user_input,
+            goal=self.current_goal,
+            last_reflection=self.goal_mgr.load_reflection(),
+            triplets=triplets,
+            api_key=self.api_key,
+        )
 
     def run_cycle(self, text: str) -> dict:
         """Run a single Metabo cycle with the provided text and return results."""
         self.cycle += 1
+        goal_message = ""
+
+        proposed = propose_goal(text, api_key=self.api_key)
+
+        if not self.current_goal:
+            self.current_goal = proposed or text.strip()
+            apply_goal_shift("", self.current_goal, self.goal_mgr, self.graph)
+        elif proposed and check_goal_shift(self.current_goal, proposed, api_key=self.api_key):
+            apply_goal_shift(self.current_goal, proposed, self.goal_mgr, self.graph)
+            self.current_goal = proposed
+            goal_message = f"Neues Ziel erkannt: {self.current_goal}"
         before = entropy_of_graph(self.graph.snapshot())
-        if self.api_key and self.client is not None:
+        if self.api_key:
             triplets = extract_triplets_via_llm(text)
         else:
             triplets = self._extract_triplets(text)
@@ -63,7 +79,8 @@ class CycleManager:
             self.graph.add_triplets(triplets)
         after = entropy_of_graph(self.graph.snapshot())
         emo = interpret_emotion(before, after)
-        reflection = self._reflect(triplets, emo["delta"])
+        reflection = self._reflect(text, triplets, emo["delta"])
+        self.goal_mgr.save_reflection(reflection.get("reflection", ""))
         log_entry = (
             f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
             f"emotion={emo['delta']:.3f}"
@@ -93,4 +110,6 @@ class CycleManager:
             "explanation": reflection.get("explanation", ""),
             "triplets": triplets,
             "log_entry": log_entry,
+            "goal": self.current_goal,
+            "goal_update": goal_message,
         }

--- a/control/metabo_cycle.py
+++ b/control/metabo_cycle.py
@@ -7,6 +7,7 @@ from goals.goal_manager import GoalManager
 from memory.graph_manager import GraphManager
 from memory.context_selector import load_context
 from parsing.triplet_parser_llm import extract_triplets_via_llm
+from memory.recall_context import recall_context
 from reflection.reflection_engine import generate_reflection
 from logs.logger import MetaboLogger
 from reasoning.emotion import interpret_emotion
@@ -42,15 +43,22 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
         logger.warning("context selection failed: %s", exc)
         context_nodes = []
 
-    prompt = (
-        f"Ziel: {goal}\n"\
-        f"Eingabe: {user_input}\n"\
-        f"Kontext: {', '.join(context_nodes)}\n"\
-        f"Letzte Reflexion: {last_reflection}"
-    )
+    try:
+        mem_facts = recall_context(scope="goal", limit=5)
+        fact_triplets = [
+            (d["subject"], d["predicate"], d["object"]) for d in mem_facts
+        ]
+    except Exception as exc:
+        logger.warning("context recall failed: %s", exc)
+        fact_triplets = []
 
     try:
-        reflection_data = generate_reflection(prompt)
+        reflection_data = generate_reflection(
+            last_user_input=user_input,
+            goal=goal,
+            last_reflection=last_reflection,
+            triplets=fact_triplets,
+        )
         reflection_text = reflection_data.get("reflection", "")
     except Exception as exc:
         logger.warning("reflection generation failed: %s", exc)

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -6,7 +6,11 @@ from pathlib import Path
 class GoalManager:
     """Simple file-based goal management."""
 
-    def __init__(self, path: str = "goals/current_goal.txt", reflection_path: str = "goals/last_reflection.txt") -> None:
+    def __init__(
+        self,
+        path: str = "memory/goal.txt",
+        reflection_path: str = "memory/last_reflection.txt",
+    ) -> None:
         self.goal_path = Path(path)
         self.goal_path.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)

--- a/goals/goal_manager.py
+++ b/goals/goal_manager.py
@@ -6,7 +6,11 @@ from pathlib import Path
 class GoalManager:
     """Simple file-based goal management."""
 
-    def __init__(self, path: str = "data/goals/current_goal.txt", reflection_path: str = "data/goals/last_reflection.txt") -> None:
+    def __init__(
+        self,
+        path: str = "memory/goal.txt",
+        reflection_path: str = "memory/last_reflection.txt",
+    ) -> None:
         self.goal_path = Path(path)
         self.goal_path.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)

--- a/goals/goal_updater.py
+++ b/goals/goal_updater.py
@@ -1,0 +1,221 @@
+"""Determine if the active goal should change based on new context."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from difflib import SequenceMatcher
+from typing import List, Tuple, Optional
+import re
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "Du bist ein Ziel-Update-Modul im KI-System MetaboMind. "
+    "Analysiere die Nutzereingabe, das bisherige Ziel, die letzte Reflexion und "
+    "die Tripel aus dem Ged\u00e4chtnis. Erkennst du einen thematischen Fokuswechsel, "
+    "dann formuliere ein neues, klares Ziel im Stil 'Untersuche X'. "
+    "Ist kein deutlicher Wechsel vorhanden, gib exakt das alte Ziel wieder. "
+    "Gib ausschlie\u00dflich das Ziel zur\u00fcck."
+)
+
+# ---------------------------------------------------------------------------
+# Goal proposal and shift utilities
+
+def _build_client(api_key: str | None):
+    if openai is None or not api_key:
+        return None
+    if hasattr(openai, "OpenAI"):
+        return openai.OpenAI(api_key=api_key)
+    openai.api_key = api_key
+    return openai
+
+
+def propose_goal(user_input: str, api_key: str | None = None) -> Optional[str]:
+    """Ask the LLM to propose a new goal based on ``user_input``."""
+    client = _build_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        return None
+
+    messages = [
+        {"role": "system", "content": "Pr\u00fcfe, ob der Nutzer ein neues Thema vorschl\u00e4gt."},
+        {"role": "user", "content": user_input},
+    ]
+    functions = [
+        {
+            "name": "propose_goal",
+            "description": "Neues Ziel extrahieren",
+            "parameters": {
+                "type": "object",
+                "properties": {"goal": {"type": "string"}},
+                "required": ["goal"],
+            },
+        }
+    ]
+
+    try:
+        if hasattr(client, "chat"):
+            resp = client.chat.completions.create(
+                model="gpt-4o",
+                temperature=0,
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp.choices[0]
+            if choice.finish_reason == "function_call":
+                fc = choice.message.function_call
+                if fc and fc.name == "propose_goal":
+                    data = json.loads(fc.arguments)
+                    return data.get("goal", "").strip()
+        else:
+            resp = client.ChatCompletion.create(
+                model="gpt-4o",
+                temperature=0,
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp["choices"][0]
+            if choice.get("finish_reason") == "function_call":
+                fc = choice["message"]["function_call"]
+                if fc["name"] == "propose_goal":
+                    data = json.loads(fc["arguments"])
+                    return data.get("goal", "").strip()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("propose_goal failed: %s", exc)
+    return None
+
+
+def check_goal_shift(current_goal: str, proposed_goal: str, api_key: str | None = None) -> bool:
+    """Return ``True`` if ``proposed_goal`` represents a significant change."""
+    proposed_goal = proposed_goal.strip()
+    if not proposed_goal:
+        return False
+    if not current_goal.strip():
+        return True
+    if proposed_goal.lower() == current_goal.lower():
+        return False
+
+    key = api_key or os.getenv("OPENAI_API_KEY")
+    if openai is not None and key:
+        try:
+            if hasattr(openai, "OpenAI"):
+                client = openai.OpenAI(api_key=key)
+                resp = client.embeddings.create(
+                    model="text-embedding-ada-002",
+                    input=[current_goal, proposed_goal],
+                )
+                vec1 = resp.data[0].embedding
+                vec2 = resp.data[1].embedding
+            else:
+                openai.api_key = key
+                resp = openai.Embedding.create(
+                    model="text-embedding-ada-002",
+                    input=[current_goal, proposed_goal],
+                )
+                vec1 = resp["data"][0]["embedding"]
+                vec2 = resp["data"][1]["embedding"]
+            from numpy import dot
+            from numpy.linalg import norm
+
+            sim = dot(vec1, vec2) / (norm(vec1) * norm(vec2))
+            return sim < 0.8
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("embedding similarity failed: %s", exc)
+
+    ratio = SequenceMatcher(None, current_goal.lower(), proposed_goal.lower()).ratio()
+    return ratio < 0.6
+
+
+def apply_goal_shift(current_goal: str, new_goal: str, goal_manager, graph) -> None:
+    """Persist ``new_goal`` and record transition from ``current_goal``."""
+    if current_goal.strip():
+        graph.add_goal_transition(current_goal, new_goal)
+    else:
+        graph.goal_graph.add_node(new_goal)
+        graph._save_goal_graph()
+    goal_manager.set_goal(new_goal)
+
+
+def _extract_explicit_goal(text: str) -> Optional[str]:
+    """Return an explicit goal mentioned in ``text``."""
+
+    patterns = [
+        r"besch[aä]ftige dich mit\s+(.+)",
+        r"konzentriere dich auf\s+(.+)",
+        r"fokussiere dich auf\s+(.+)",
+        r"untersuche\s+(.+)",
+        r"analysiere\s+(.+)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text, flags=re.IGNORECASE)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def update_goal(
+    user_input: str,
+    last_goal: str,
+    last_reflection: str,
+    triplets: List[Tuple[str, str, str]],
+) -> str:
+    """Return a new goal if the focus changed, otherwise ``last_goal``."""
+    explicit = _extract_explicit_goal(user_input)
+    if explicit and explicit.lower() not in last_goal.lower():
+        return explicit
+
+    if openai is None:
+        logger.error("openai package not installed")
+        return last_goal
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.error("No OpenAI API key provided")
+        return last_goal
+
+    facts = "; ".join([f"{s} {p} {o}" for s, p, o in triplets])
+
+    user_content = f"Eingabe: {user_input}\nAktuelles Ziel: {last_goal}"
+    if last_reflection.strip():
+        user_content += f"\nLetzte Reflexion: {last_reflection.strip()}"
+    if facts:
+        user_content += f"\nTripel: {facts}"
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        if hasattr(openai, "OpenAI"):
+            client = openai.OpenAI(api_key=api_key)
+            response = client.chat.completions.create(
+                model="gpt-4o",
+                temperature=0,
+                messages=messages,
+            )
+            text = response.choices[0].message.content
+        else:
+            openai.api_key = api_key
+            response = openai.ChatCompletion.create(
+                model="gpt-4o",
+                temperature=0,
+                messages=messages,
+            )
+            text = response["choices"][0]["message"]["content"]
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("LLM request failed: %s", exc)
+        return last_goal
+
+    new_goal = text.strip()
+    if not new_goal:
+        return last_goal
+    return new_goal
+

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from control.metabo_cycle import run_metabo_cycle
 from goals.goal_manager import set_goal, get_active_goal
+from goals.goal_updater import update_goal
 from interface.metabo_gui import MetaboGUI
 
 
@@ -43,8 +44,15 @@ def main() -> None:
             continue
 
         result = run_metabo_cycle(user_input)
+        new_goal = update_goal(
+            user_input=user_input,
+            last_goal=result.get("goal", ""),
+            last_reflection=result.get("reflection", ""),
+            triplets=result.get("triplets", []),
+        )
+        set_goal(new_goal)
         print("[Zyklus abgeschlossen]")
-        print(f"Ziel: {result['goal']}")
+        print(f"Aktuelles Ziel: {new_goal}")
         print(f"Antwort: {result['reflection']}")
         print(f"Emotion: {result['emotion']} (Δ={result['delta']:+.2f})")
         if result['triplets']:

--- a/memory/intention_graph.py
+++ b/memory/intention_graph.py
@@ -1,5 +1,6 @@
 
 import os
+from pathlib import Path
 from typing import List, Tuple
 
 import networkx as nx
@@ -7,12 +8,23 @@ import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
 
 class IntentionGraph:
-    """Graph storing intention triples with persistent GML saving."""
+    """Graph storing intention triples and goal transitions with persistence."""
 
-    def __init__(self, filepath: str = "data/graph.gml"):
-        """Load existing graph from ``filepath`` or create a new one."""
+    def __init__(self, filepath: str = "data/graph.gml", goal_path: str | None = None):
+        """Load existing graphs or create new ones.
+
+        Parameters
+        ----------
+        filepath:
+            Path to the knowledge graph file used for triplets.
+        goal_path:
+            Path to the directed goal graph. Defaults to ``memory/intent_graph.gml``.
+        """
+
         self.filepath = filepath
+        self.goal_path = Path(goal_path or "memory/intent_graph.gml")
         self.load_graph()
+        self._load_goal_graph()
 
     def load_graph(self):
         """Load the graph from ``self.filepath`` if it exists."""
@@ -37,6 +49,27 @@ class IntentionGraph:
         except Exception as exc:
             print(f"[Graph] Fehler beim Speichern: {exc}")
 
+    def _load_goal_graph(self) -> None:
+        """Load the directed goal graph from ``self.goal_path`` if available."""
+        if self.goal_path.exists():
+            try:
+                self.goal_graph = nx.read_gml(self.goal_path)
+                if not isinstance(self.goal_graph, nx.DiGraph):
+                    self.goal_graph = nx.DiGraph(self.goal_graph)
+                print(f"[GoalGraph] Lade bestehenden Graph aus {self.goal_path}")
+            except Exception as exc:  # pragma: no cover - log for debugging
+                print(f"[GoalGraph] Fehler beim Laden, erstelle neuen Graph: {exc}")
+                self.goal_graph = nx.DiGraph()
+        else:
+            self.goal_graph = nx.DiGraph()
+
+    def _save_goal_graph(self) -> None:
+        """Persist the goal graph to disk."""
+        try:
+            nx.write_gml(self.goal_graph, self.goal_path)
+        except Exception as exc:  # pragma: no cover - log for debugging
+            print(f"[GoalGraph] Fehler beim Speichern: {exc}")
+
 
     def add_triplets(self, triplets: List[Tuple[str, str, str]]):
         """Add a list of (subject, relation, object) triples to the graph."""
@@ -48,6 +81,45 @@ class IntentionGraph:
     def snapshot(self) -> nx.MultiDiGraph:
         """Return a copy of the current graph."""
         return self.graph.copy()
+
+    # ------------------------------------------------------------------
+    # Goal transition management
+
+    def add_goal_transition(self, previous_goal: str, new_goal: str) -> None:
+        """Add a directed edge from ``previous_goal`` to ``new_goal``.
+
+        Nodes are created if they do not yet exist. Duplicate edges are
+        ignored. The goal graph is persisted after modification.
+        """
+
+        self.goal_graph.add_node(previous_goal)
+        self.goal_graph.add_node(new_goal)
+        if not self.goal_graph.has_edge(previous_goal, new_goal):
+            self.goal_graph.add_edge(previous_goal, new_goal)
+            self._save_goal_graph()
+
+    def get_goal_path(self) -> List[str]:
+        """Return a list representing the current goal path."""
+
+        if len(self.goal_graph) == 0:
+            return []
+        try:
+            return list(nx.topological_sort(self.goal_graph))
+        except nx.NetworkXUnfeasible:
+            start = next(iter(self.goal_graph.nodes()))
+            return list(nx.dfs_preorder_nodes(self.goal_graph, start))
+
+    def visualize_graph(self, output_path: str = "memory/intent_graph.png") -> None:
+        """Create a simple PNG visualization of the goal graph."""
+
+        import matplotlib.pyplot as plt
+
+        plt.figure(figsize=(8, 6))
+        pos = nx.spring_layout(self.goal_graph)
+        nx.draw(self.goal_graph, pos, with_labels=True, arrows=True, node_color="lightblue")
+        plt.tight_layout()
+        plt.savefig(output_path)
+        plt.close()
 
 
 def expand_target_neighborhood(
@@ -82,4 +154,5 @@ def expand_target_neighborhood(
 
     ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
     return [n for n, _ in ranked[:top_k]]
+
 

--- a/tests/test_cycle_manager.py
+++ b/tests/test_cycle_manager.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from control.cycle_manager import CycleManager
+
+
+def setup_common(monkeypatch, cm):
+    monkeypatch.setattr(cm.graph, "_save_goal_graph", lambda: None)
+    monkeypatch.setattr(cm.graph, "save_graph", lambda: None)
+    monkeypatch.setattr("control.cycle_manager.extract_triplets_via_llm", lambda text: [])
+    monkeypatch.setattr("control.cycle_manager.generate_reflection", lambda **k: {"reflection": ""})
+
+
+def test_goal_switch(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr("control.cycle_manager.propose_goal", lambda t, api_key=None: "Neu")
+    monkeypatch.setattr("control.cycle_manager.check_goal_shift", lambda cur, new, api_key=None: True)
+    called = {}
+    def fake_apply(cur, new, gm, graph):
+        called["args"] = (cur, new)
+        gm.set_goal(new)
+    monkeypatch.setattr("control.cycle_manager.apply_goal_shift", fake_apply)
+    cm.current_goal = "Alt"
+    res = cm.run_cycle("irgendwas")
+    assert cm.current_goal == "Neu"
+    assert res["goal"] == "Neu"
+    assert called["args"] == ("Alt", "Neu")
+    assert "Neues Ziel" in res["goal_update"]
+
+
+def test_no_goal_switch(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr("control.cycle_manager.propose_goal", lambda t, api_key=None: None)
+    cm.current_goal = "Alt"
+    res = cm.run_cycle("etwas")
+    assert cm.current_goal == "Alt"
+    assert res["goal_update"] == ""
+
+
+def test_first_goal(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr("control.cycle_manager.propose_goal", lambda t, api_key=None: "Start")
+    cm.current_goal = ""
+    res = cm.run_cycle("hey")
+    assert cm.current_goal == "Start"
+    assert res["goal"] == "Start"
+    assert res["goal_update"] == ""

--- a/tests/test_goal_selector.py
+++ b/tests/test_goal_selector.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from goals import goal_updater as goal_selector
+from goals.goal_manager import GoalManager
+from memory.intention_graph import IntentionGraph
+
+
+def test_propose_goal_no_openai(monkeypatch):
+    monkeypatch.setattr(goal_selector, "openai", None)
+    assert goal_selector.propose_goal("hi") is None
+
+
+def test_check_goal_shift_basic(monkeypatch):
+    monkeypatch.setattr(goal_selector, "openai", None)
+    assert goal_selector.check_goal_shift("A", "B")
+    assert not goal_selector.check_goal_shift("Goal", "Goal")
+
+
+def test_apply_goal_shift(tmp_path, monkeypatch):
+    gm = GoalManager(path=str(tmp_path / "goal.txt"))
+    ig = IntentionGraph(filepath=str(tmp_path / "g.gml"))
+    called = {}
+    monkeypatch.setattr(ig, "add_goal_transition", lambda a, b: called.setdefault("edge", (a, b)))
+    goal_selector.apply_goal_shift("Old", "New", gm, ig)
+    assert gm.get_goal() == "New"
+    assert called["edge"] == ("Old", "New")

--- a/tests/test_goal_updater.py
+++ b/tests/test_goal_updater.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from goals import goal_updater
+
+
+def test_missing_openai(monkeypatch):
+    monkeypatch.setattr(goal_updater, "openai", None)
+    res = goal_updater.update_goal("hi", "old", "", [])
+    assert res == "old"
+
+
+def test_missing_api_key(monkeypatch):
+    dummy = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: None))
+    monkeypatch.setattr(goal_updater, "openai", dummy)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    res = goal_updater.update_goal("hi", "old", "", [])
+    assert res == "old"
+
+
+def test_new_goal(monkeypatch):
+    dummy = types.SimpleNamespace()
+    def create(model, temperature, messages):
+        return {"choices": [{"message": {"content": "Untersuche X"}}]}
+    dummy.ChatCompletion = types.SimpleNamespace(create=create)
+    monkeypatch.setattr(goal_updater, "openai", dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    res = goal_updater.update_goal("frage", "Alt", "", [])
+    assert res == "Untersuche X"
+
+
+def test_explicit_command(monkeypatch):
+    monkeypatch.setattr(goal_updater, "openai", None)
+    res = goal_updater.update_goal("Beschäftige dich mit Z", "Alt", "", [])
+    assert res == "Z"

--- a/zip_sources.sh
+++ b/zip_sources.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Compress all Python source files of MetaboMind into a ZIP archive
+# Usage: ./zip_sources.sh [output.zip]
+
+set -euo pipefail
+
+out_file="${1:-metabomind_sources.zip}"
+
+# Find all .py files excluding __pycache__ directories and feed them to zip
+find . -type d -name '__pycache__' -prune -o -name '*.py' -print | zip -@ "$out_file"
+
+echo "Created $out_file"


### PR DESCRIPTION
## Summary
- support directed goal graph stored at `memory/intent_graph.gml`
- load and save the goal graph automatically
- add helpers to add transitions, list goal path and visualize the graph
- detect new topics in `CycleManager` and update goals accordingly
- handle explicit goal commands like "Beschäftige dich mit X"
- use LLM function calls to decide on goal switching
- integrate new goal selection via propose_goal
- refactor goal utilities into `goal_updater`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea3c3cb90832eb766bfd820c97b64