### PR TITLE
Use shared memory and LLM client

### DIFF
--- a/cfg/config.py
+++ b/cfg/config.py
@@ -1,0 +1,54 @@
+PROMPTS = {
+    'goal_updater_system': (
+        "Du bist ein Ziel-Update-Modul im KI-System MetaboMind. "
+        "Analysiere die Nutzereingabe, das bisherige Ziel, die letzte Reflexion und "
+        "die Tripel aus dem Gedächtnis. Erkennst du einen thematischen Fokuswechsel, "
+        "dann formuliere ein neues, klares Ziel im Stil 'Untersuche X'. "
+        "Ist kein deutlicher Wechsel vorhanden, gib exakt das alte Ziel wieder. "
+        "Gib ausschließlich das Ziel zurück."
+    ),
+    'goal_engine_system': (
+        "Du bist ein Denkagent in einem KI-System namens MetaboMind. "
+        "Deine Aufgabe ist es, eine kurze, neue Aussage zu formulieren, "
+        "die das folgende Ziel inhaltlich weiterverfolgt. Nutze dazu auch "
+        "die letzte Reflexion, wenn vorhanden. Formuliere die Aussage in "
+        "natürlicher Sprache, als würdest du einen neuen Gedanken entwickeln. "
+        "Gib nur den einen Satz zurück – keine Erklärung, keine Wiederholung des Ziels."
+    ),
+    'subgoal_planner_system': (
+        "Du bist ein Planungsagent in einem KI-System namens MetaboMind. "
+        "Zerlege das folgende Ziel in 2 bis 5 umsetzbare Teilziele. "
+        "Formuliere jedes Teilziel als kurzen Satz im Klartext. "
+        "Gib eine JSON-Liste der Teilziele zurück."
+    ),
+    'triplet_parser_system': (
+        "Extrahiere aus folgendem deutschen Text alle bedeutungsvollen Aussagen als "
+        "Tripel (Subjekt, Prädikat, Objekt). "
+        "Gib nur eine Liste von Tripeln im Format [('Subjekt', 'Prädikat', 'Objekt')] "
+        "zurück. Kein Kommentar, keine Erklärungen."
+    ),
+    'goal_detector_system': (
+        "Du bist ein Zielerkennungsmodul im KI-System MetaboMind. "
+        "Analysiere die aktuelle und vorherige Konversation, um zu erkennen, "
+        "ob ein neues Thema vorgeschlagen wird. Gib ein JSON-Objekt zurück."
+    ),
+    'propose_goal_system': "Pr\u00fcfe, ob der Nutzer ein neues Thema vorschl\u00e4gt.",
+    'reflection_system': (
+        "Du bist ein Denkagent im KI-System MetaboMind. "
+        "Beziehe dich direkt auf die Nutzereingabe und verfolge dabei das Ziel. "
+        "Nutze die Tripel aus dem Gedächtnis und die letzte Reflexion, um den Gedanken weiterzuentwickeln. "
+        "Antworte der Nutzerin oder dem Nutzer in genau einem klaren Satz ohne Floskeln."
+    ),
+}
+
+MODELS = {
+    'chat': 'gpt-4o',
+    'embedding': 'text-embedding-ada-002',
+    'subgoal': 'gpt-4o-mini',
+}
+
+TEMPERATURES = {
+    'chat': 0,
+    'subgoal': 0.3,
+    'generate_next_input': 0.7,
+}

--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -3,41 +3,27 @@ from __future__ import annotations
 import os
 from typing import List, Tuple
 
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from goals import goal_engine
+from memory_manager import get_memory_manager
 
 from logs.logger import MetaboLogger
-from reasoning.emotion import interpret_emotion
 
 from parsing.triplet_parser_llm import extract_triplets_via_llm
 
-from reflection.reflection_engine import generate_reflection
-
-from memory.intention_graph import IntentionGraph
-from control.metabo_rules import METABO_RULES
-from reasoning.entropy_analyzer import entropy_of_graph
+from reflection.reflection_engine import generate_reflection, run_llm_task
 
 
 class CycleManager:
     """Manages Metabo cycles including graph updates and reflections."""
 
     def __init__(self, api_key: str | None = None, logger: MetaboLogger | None = None):
-        key = api_key or os.getenv("OPENAI_API_KEY")
-        self.api_key = key
-        if key and openai is not None:
-            if hasattr(openai, "OpenAI"):
-                self.client = openai.OpenAI(api_key=key)
-            else:
-                openai.api_key = key
-                self.client = openai
-        else:
-            self.client = None
-        self.graph = IntentionGraph()
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.memory = get_memory_manager()
         self.cycle = 0
         self.logger = logger
         self.logs: List[str] = []
+        self.current_goal = goal_engine.get_current_goal()
+
 
     def _extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
         """Naive fallback extraction of triples when no API key is available."""
@@ -46,30 +32,63 @@ class CycleManager:
             return [(words[0], words[1], " ".join(words[2:]))]
         return []
 
-    def _reflect(self, triplets: List[Tuple[str, str, str]], emotion: float) -> dict:
+    def _reflect(
+        self,
+        user_input: str,
+        triplets: List[Tuple[str, str, str]],
+    ) -> dict:
         """Use the reflection engine to analyse triplets and emotion."""
-        content = f"Triples: {triplets}\nEmotion: {emotion:.3f}"
-        return generate_reflection(content, api_key=self.api_key)
+        return generate_reflection(
+            last_user_input=user_input,
+            goal=self.current_goal,
+            last_reflection=self.memory.load_reflection(),
+            triplets=triplets,
+            api_key=self.api_key,
+        )
 
     def run_cycle(self, text: str) -> dict:
         """Run a single Metabo cycle with the provided text and return results."""
         self.cycle += 1
-        before = entropy_of_graph(self.graph.snapshot())
-        if self.api_key and self.client is not None:
+
+        if self.api_key:
             triplets = extract_triplets_via_llm(text)
         else:
             triplets = self._extract_triplets(text)
-        if triplets:
-            self.graph.add_triplets(triplets)
-        after = entropy_of_graph(self.graph.snapshot())
-        emo = interpret_emotion(before, after)
-        reflection = self._reflect(triplets, emo["delta"])
+
+        before, after = self.memory.store_triplets(triplets)
+        emo = self.memory.save_emotion(before, after)
+
+        new_goal = goal_engine.update_goal(
+            user_input=text,
+            last_reflection=self.memory.load_reflection(),
+            triplets=triplets,
+        )
+
+        goal_message = ""
+        goal_reflection = ""
+        if new_goal != self.current_goal:
+            if self.current_goal:
+                self.memory.graph.add_goal_transition(self.current_goal, new_goal)
+            else:
+                self.memory.graph.goal_graph.add_node(new_goal)
+                self.memory.graph._save_goal_graph()
+            goal_reflection = run_llm_task(
+                f"Reflektiere kurz den Zielwechsel von '{self.current_goal}' zu '{new_goal}'.",
+                api_key=self.api_key,
+            )
+            if goal_reflection:
+                self.memory.store_reflection(goal_reflection)
+            self.current_goal = new_goal
+            goal_message = f"Neues Ziel erkannt: {self.current_goal}"
+
+        reflection = self._reflect(text, triplets)
+        self.memory.store_reflection(reflection.get("reflection", ""))
+
         log_entry = (
             f"Cycle{self.cycle}: ent_b={before:.3f} ent_a={after:.3f} "
             f"emotion={emo['delta']:.3f}"
         )
         self.logs.append(log_entry)
-        self.graph.save_graph()
 
         if self.logger:
             self.logger.log_cycle(
@@ -93,4 +112,7 @@ class CycleManager:
             "explanation": reflection.get("explanation", ""),
             "triplets": triplets,
             "log_entry": log_entry,
+            "goal": self.current_goal,
+            "goal_update": goal_message,
+            "goal_reflection": goal_reflection,
         }

--- a/control/metabo_cycle.py
+++ b/control/metabo_cycle.py
@@ -4,27 +4,52 @@ import logging
 from typing import Dict
 
 from goals.goal_manager import GoalManager
-from memory.graph_manager import GraphManager
+from goals.goal_updater import propose_goal, check_goal_shift
+from memory_manager import get_memory_manager
 from memory.context_selector import load_context
 from parsing.triplet_parser_llm import extract_triplets_via_llm
+from memory.recall_context import recall_context
 from reflection.reflection_engine import generate_reflection
 from logs.logger import MetaboLogger
 from reasoning.emotion import interpret_emotion
 from reasoning.entropy_analyzer import entropy_of_graph
 from goals.subgoal_planner import decompose_goal
 from goals.subgoal_executor import execute_first_subgoal
+from difflib import SequenceMatcher
 
 logger = logging.getLogger(__name__)
+
+
+def is_new_topic(user_input: str, current_goal: str) -> bool:
+    """Return True if ``user_input`` appears unrelated to ``current_goal``."""
+    if not user_input or not current_goal:
+        return False
+    prefix = user_input.lower().strip()[:25]
+    return prefix not in current_goal.lower()
 
 
 def run_metabo_cycle(user_input: str) -> Dict[str, object]:
     """Execute one MetaboMind cycle and return a structured result."""
     goal_mgr = GoalManager()
-    graph_mgr = GraphManager()
+    memory = get_memory_manager()
     log = MetaboLogger()
 
     goal = goal_mgr.get_goal()
     last_reflection = goal_mgr.load_reflection()
+
+    proposed = propose_goal(user_input)
+    if not proposed and is_new_topic(user_input, goal):
+        proposed = user_input.strip()
+
+    if proposed and check_goal_shift(goal, proposed):
+        if goal:
+            memory.graph.add_goal_transition(goal, proposed)
+        else:
+            memory.graph.goal_graph.add_node(proposed)
+            memory.graph._save_goal_graph()
+        goal_mgr.set_goal(proposed)
+        logger.info("Neues Ziel erkannt: %s -> %s", goal, proposed)
+        goal = proposed
 
     try:
         subgoals = decompose_goal(goal, last_reflection)
@@ -33,24 +58,31 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
         subgoals = [goal]
     goal = execute_first_subgoal(goal, subgoals)
 
-    graph_snapshot = graph_mgr.snapshot()
+    graph_snapshot = memory.graph.snapshot()
     entropy_before = entropy_of_graph(graph_snapshot)
 
     try:
-        context_nodes = load_context(graph_mgr.graph, goal)
+        context_nodes = load_context(memory.graph.graph, goal)
     except Exception as exc:
         logger.warning("context selection failed: %s", exc)
         context_nodes = []
 
-    prompt = (
-        f"Ziel: {goal}\n"\
-        f"Eingabe: {user_input}\n"\
-        f"Kontext: {', '.join(context_nodes)}\n"\
-        f"Letzte Reflexion: {last_reflection}"
-    )
+    try:
+        mem_facts = recall_context(scope="goal", limit=5)
+        fact_triplets = [
+            (d["subject"], d["predicate"], d["object"]) for d in mem_facts
+        ]
+    except Exception as exc:
+        logger.warning("context recall failed: %s", exc)
+        fact_triplets = []
 
     try:
-        reflection_data = generate_reflection(prompt)
+        reflection_data = generate_reflection(
+            last_user_input=user_input,
+            goal=goal,
+            last_reflection=last_reflection,
+            triplets=fact_triplets,
+        )
         reflection_text = reflection_data.get("reflection", "")
     except Exception as exc:
         logger.warning("reflection generation failed: %s", exc)
@@ -65,17 +97,14 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
 
     if triplets:
         try:
-            graph_mgr.add_triplets(triplets)
+            memory.graph.add_triplets(triplets)
         except Exception as exc:
             logger.warning("graph update failed: %s", exc)
 
-    entropy_after = entropy_of_graph(graph_mgr.snapshot())
+    entropy_after = entropy_of_graph(memory.graph.snapshot())
     emotion = interpret_emotion(entropy_before, entropy_after)
 
-    try:
-        graph_mgr.save()
-    except Exception as exc:
-        logger.warning("graph save failed: %s", exc)
+
 
     try:
         log.log_cycle(

--- a/control/takt_engine.py
+++ b/control/takt_engine.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from goals import goal_engine
+from memory_manager import get_memory_manager
+from reflection.reflection_engine import run_llm_task
+
+
+def run_metabotakt(api_key: str | None = None) -> Dict[str, object]:
+    """Execute a Metabotakt without user input."""
+    memory = get_memory_manager()
+    current_goal = goal_engine.get_current_goal()
+
+    last_entropy = memory.load_last_entropy()
+    current_entropy = memory.calculate_entropy()
+    delta = current_entropy - last_entropy
+    memory.store_last_entropy(current_entropy)
+
+    emotion = memory.map_entropy_to_emotion(delta)
+
+    prompt = (
+        f"Reflektiere den aktuellen Stand: Ziel war {current_goal}, "
+        f"\u0394E war {delta:+.2f}. Welche Bedeutung hat das?"
+    )
+    reflection = run_llm_task(prompt, api_key=api_key)
+    if reflection:
+        memory.store_reflection(reflection)
+
+    new_goal = goal_engine.update_goal(
+        user_input=reflection,
+        last_reflection=reflection,
+        triplets=[],
+    )
+    goal_update = ""
+    if new_goal != current_goal:
+        memory.graph.add_goal_transition(current_goal, new_goal)
+        current_goal = new_goal
+        goal_update = f"Neues Ziel erkannt: {new_goal}"
+
+    return {
+        "goal": current_goal,
+        "goal_update": goal_update,
+        "entropy": current_entropy,
+        "delta": delta,
+        "emotion": emotion["emotion"],
+        "intensity": emotion["intensity"],
+        "reflection": reflection,
+    }

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -6,7 +6,11 @@ from pathlib import Path
 class GoalManager:
     """Simple file-based goal management."""
 
-    def __init__(self, path: str = "goals/current_goal.txt", reflection_path: str = "goals/last_reflection.txt") -> None:
+    def __init__(
+        self,
+        path: str = "memory/goal.txt",
+        reflection_path: str = "memory/last_reflection.txt",
+    ) -> None:
         self.goal_path = Path(path)
         self.goal_path.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)

--- a/goals/goal_engine.py
+++ b/goals/goal_engine.py
@@ -3,37 +3,31 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import List, Tuple
 
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from goals.goal_manager import GoalManager
+from goals.goal_updater import update_goal as _llm_update_goal
+
+from llm_client import get_client
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
 
 logger = logging.getLogger(__name__)
 
-_SYSTEM_PROMPT = (
-    "Du bist ein Denkagent in einem KI-System namens MetaboMind. "
-    "Deine Aufgabe ist es, eine kurze, neue Aussage zu formulieren, "
-    "die das folgende Ziel inhaltlich weiterverfolgt. Nutze dazu auch "
-    "die letzte Reflexion, wenn vorhanden. Formuliere die Aussage in "
-    "natürlicher Sprache, als würdest du einen neuen Gedanken entwickeln. "
-    "Gib nur den einen Satz zurück – keine Erklärung, keine Wiederholung des Ziels."
-)
+_GOAL_MGR = GoalManager()
+
+_SYSTEM_PROMPT = PROMPTS['goal_engine_system']
 
 
 def generate_next_input(
     goal: str,
     previous_reflection: str = "",
-    model: str = "gpt-3.5-turbo",
-    temperature: float = 0.7,
+    model: str = MODELS['chat'],
+    temperature: float = TEMPERATURES['generate_next_input'],
 ) -> str:
     """Generate a short statement that pursues ``goal`` further."""
-    if openai is None:
-        raise ImportError("openai package not installed")
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise EnvironmentError("OPENAI_API_KEY not set")
+    client = get_client(os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        raise EnvironmentError("OPENAI_API_KEY not set or client unavailable")
 
     reflection = previous_reflection.strip()[:300] if previous_reflection else ""
     content = f"Ziel: {goal}"
@@ -46,8 +40,7 @@ def generate_next_input(
     ]
 
     try:
-        if hasattr(openai, "OpenAI"):
-            client = openai.OpenAI(api_key=api_key)
+        if hasattr(client, "chat"):
             response = client.chat.completions.create(
                 model=model,
                 temperature=temperature,
@@ -55,8 +48,7 @@ def generate_next_input(
             )
             text = response.choices[0].message.content
         else:
-            openai.api_key = api_key
-            response = openai.ChatCompletion.create(
+            response = client.ChatCompletion.create(
                 model=model,
                 temperature=temperature,
                 messages=messages,
@@ -69,6 +61,29 @@ def generate_next_input(
     if not text or not text.strip():
         return "Verantwortung ist der Preis der Freiheit."
     return text.strip()
+
+
+def get_current_goal() -> str:
+    """Return the currently stored goal."""
+    return _GOAL_MGR.get_goal()
+
+
+def update_goal(
+    user_input: str,
+    last_reflection: str,
+    triplets: List[Tuple[str, str, str]],
+) -> str:
+    """Determine and persist a new goal based on ``user_input``."""
+    current = _GOAL_MGR.get_goal()
+    new_goal = _llm_update_goal(
+        user_input=user_input,
+        last_goal=current,
+        last_reflection=last_reflection,
+        triplets=triplets,
+    )
+    if new_goal != current:
+        _GOAL_MGR.set_goal(new_goal)
+    return new_goal
 
 
 if __name__ == "__main__":

--- a/goals/goal_executor.py
+++ b/goals/goal_executor.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities to run internal goal-driven actions."""
+
+from __future__ import annotations
 
 from goals.goal_engine import generate_next_input
 from goals.goal_manager import get_active_goal, load_last_reflection

--- a/goals/goal_manager.py
+++ b/goals/goal_manager.py
@@ -6,7 +6,11 @@ from pathlib import Path
 class GoalManager:
     """Simple file-based goal management."""
 
-    def __init__(self, path: str = "data/goals/current_goal.txt", reflection_path: str = "data/goals/last_reflection.txt") -> None:
+    def __init__(
+        self,
+        path: str = "memory/goal.txt",
+        reflection_path: str = "memory/last_reflection.txt",
+    ) -> None:
         self.goal_path = Path(path)
         self.goal_path.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)

--- a/goals/goal_updater.py
+++ b/goals/goal_updater.py
@@ -1,0 +1,201 @@
+"""Determine if the active goal should change based on new context."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from difflib import SequenceMatcher
+from typing import List, Tuple, Optional
+import re
+
+from llm_client import get_client
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = PROMPTS['goal_updater_system']
+
+# ---------------------------------------------------------------------------
+# Goal proposal and shift utilities
+
+def propose_goal(user_input: str, api_key: str | None = None) -> Optional[str]:
+    """Ask the LLM to propose a new goal based on ``user_input``."""
+    client = get_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        return None
+
+    messages = [
+        {"role": "system", "content": PROMPTS['propose_goal_system']},
+        {"role": "user", "content": user_input},
+    ]
+    functions = [
+        {
+            "name": "propose_goal",
+            "description": "Neues Ziel extrahieren",
+            "parameters": {
+                "type": "object",
+                "properties": {"goal": {"type": "string"}},
+                "required": ["goal"],
+            },
+        }
+    ]
+
+    try:
+        if hasattr(client, "chat"):
+            resp = client.chat.completions.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp.choices[0]
+            if choice.finish_reason == "function_call":
+                fc = choice.message.function_call
+                if fc and fc.name == "propose_goal":
+                    data = json.loads(fc.arguments)
+                    return data.get("goal", "").strip()
+        else:
+            resp = client.ChatCompletion.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp["choices"][0]
+            if choice.get("finish_reason") == "function_call":
+                fc = choice["message"]["function_call"]
+                if fc["name"] == "propose_goal":
+                    data = json.loads(fc["arguments"])
+                    return data.get("goal", "").strip()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("propose_goal failed: %s", exc)
+    return None
+
+
+def check_goal_shift(current_goal: str, proposed_goal: str, api_key: str | None = None) -> bool:
+    """Return ``True`` if ``proposed_goal`` represents a significant change."""
+    proposed_goal = proposed_goal.strip()
+    if not proposed_goal:
+        return False
+    if not current_goal.strip():
+        return True
+    if proposed_goal.lower() == current_goal.lower():
+        return False
+
+    key = api_key or os.getenv("OPENAI_API_KEY")
+    client = get_client(key)
+    if client is not None:
+        try:
+            if hasattr(client, "embeddings"):
+                resp = client.embeddings.create(
+                    model=MODELS['embedding'],
+                    input=[current_goal, proposed_goal],
+                )
+                vec1 = resp.data[0].embedding
+                vec2 = resp.data[1].embedding
+            else:
+                resp = client.Embedding.create(
+                    model=MODELS['embedding'],
+                    input=[current_goal, proposed_goal],
+                )
+                vec1 = resp["data"][0]["embedding"]
+                vec2 = resp["data"][1]["embedding"]
+            from numpy import dot
+            from numpy.linalg import norm
+
+            sim = dot(vec1, vec2) / (norm(vec1) * norm(vec2))
+            return sim < 0.8
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("embedding similarity failed: %s", exc)
+
+    ratio = SequenceMatcher(None, current_goal.lower(), proposed_goal.lower()).ratio()
+    return ratio < 0.6
+
+
+def apply_goal_shift(current_goal: str, new_goal: str, goal_manager, graph) -> None:
+    """Persist ``new_goal`` and record transition from ``current_goal``."""
+    if current_goal.strip():
+        graph.add_goal_transition(current_goal, new_goal)
+    else:
+        graph.goal_graph.add_node(new_goal)
+        graph._save_goal_graph()
+    goal_manager.set_goal(new_goal)
+
+
+def _extract_explicit_goal(text: str) -> Optional[str]:
+    """Return an explicit goal mentioned in ``text``."""
+
+    patterns = [
+        r"besch[aä]ftige dich mit\s+(.+)",
+        r"konzentriere dich auf\s+(.+)",
+        r"fokussiere dich auf\s+(.+)",
+        r"untersuche\s+(.+)",
+        r"analysiere\s+(.+)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text, flags=re.IGNORECASE)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def update_goal(
+    user_input: str,
+    last_goal: str,
+    last_reflection: str,
+    triplets: List[Tuple[str, str, str]],
+) -> str:
+    """Return a new goal if the focus changed, otherwise ``last_goal``."""
+
+    explicit = _extract_explicit_goal(user_input)
+    if explicit and check_goal_shift(last_goal, explicit):
+        return explicit
+
+    proposed = propose_goal(user_input)
+    if proposed and check_goal_shift(last_goal, proposed):
+        return proposed
+
+    client = get_client(os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        logger.error("No OpenAI client available")
+        return last_goal
+
+    facts = "; ".join([f"{s} {p} {o}" for s, p, o in triplets])
+
+    user_content = f"Eingabe: {user_input}\nAktuelles Ziel: {last_goal}"
+    if last_reflection.strip():
+        user_content += f"\nLetzte Reflexion: {last_reflection.strip()}"
+    if facts:
+        user_content += f"\nTripel: {facts}"
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        if hasattr(client, "chat"):
+            response = client.chat.completions.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+            )
+            text = response.choices[0].message.content
+        else:
+            response = client.ChatCompletion.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+            )
+            text = response["choices"][0]["message"]["content"]
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("LLM request failed: %s", exc)
+        return last_goal
+
+    new_goal = text.strip()
+    if not new_goal:
+        return last_goal
+    return new_goal
+

--- a/goals/subgoal_planner.py
+++ b/goals/subgoal_planner.py
@@ -6,36 +6,25 @@ import logging
 import os
 
 from utils.json_utils import parse_json_safe
-
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from llm_client import get_client
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
 
 logger = logging.getLogger(__name__)
 
-_SYSTEM_PROMPT = (
-    "Du bist ein Planungsagent in einem KI-System namens MetaboMind. "
-    "Zerlege das folgende Ziel in 2 bis 5 umsetzbare Teilziele. "
-    "Formuliere jedes Teilziel als kurzen Satz im Klartext. "
-    "Gib eine JSON-Liste der Teilziele zur\xFCck."
-)
+_SYSTEM_PROMPT = PROMPTS['subgoal_planner_system']
 
 
 def decompose_goal(
     goal: str,
     context: str = "",
     *,
-    model: str = "gpt-4o-mini",
-    temperature: float = 0.3,
+    model: str = MODELS['subgoal'],
+    temperature: float = TEMPERATURES['subgoal'],
 ) -> List[str]:
     """Return a list of subgoals decomposed from ``goal``."""
-    if openai is None:
-        raise ImportError("openai package not installed")
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise EnvironmentError("OPENAI_API_KEY not set")
+    client = get_client(os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        raise EnvironmentError("OPENAI_API_KEY not set or client unavailable")
 
     user_content = f"Ziel: {goal}"
     if context:
@@ -47,8 +36,7 @@ def decompose_goal(
     ]
 
     try:
-        if hasattr(openai, "OpenAI"):
-            client = openai.OpenAI(api_key=api_key)
+        if hasattr(client, "chat"):
             response = client.chat.completions.create(
                 model=model,
                 temperature=temperature,
@@ -56,8 +44,7 @@ def decompose_goal(
             )
             text = response.choices[0].message.content
         else:
-            openai.api_key = api_key
-            response = openai.ChatCompletion.create(
+            response = client.ChatCompletion.create(
                 model=model,
                 temperature=temperature,
                 messages=messages,
@@ -72,7 +59,7 @@ def decompose_goal(
     if isinstance(data, list) and all(isinstance(s, str) for s in data):
         subgoals = [s.strip() for s in data if s.strip()]
     else:
-        lines = [l.strip("-•* \t") for l in text.splitlines() if l.strip()]
+        lines = [line.strip("-•* \t") for line in text.splitlines() if line.strip()]
         if 2 <= len(lines) <= 5:
             subgoals = lines
 

--- a/interface/metabo_gui.py
+++ b/interface/metabo_gui.py
@@ -8,17 +8,40 @@ from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 
 from control.metabo_cycle import run_metabo_cycle
+from control.takt_engine import run_metabotakt
 from goals.goal_manager import get_active_goal, set_goal
+from memory_manager import get_memory_manager
+import llm_client
 
 
 class MetaboGUI:
     """Simple interface wrapping the CLI functionality."""
 
     def __init__(self) -> None:
+        llm_client.init_client()
+        self.memory = get_memory_manager()
+
         self.root = tk.Tk()
         self.root.title("MetaboMind GUI")
+        self.root.geometry("800x600")
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self._build_menu()
+
+        style = ttk.Style(self.root)
+        if "clam" in style.theme_names():
+            style.theme_use("clam")
+        style.configure("TButton", padding=6)
 
         self._build_layout()
+
+    # Layout helpers -----------------------------------------------------
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self.root)
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label="Graph speichern", command=self._save_graph)
+        menubar.add_cascade(label="Datei", menu=file_menu)
+        self.root.config(menu=menubar)
 
     # Layout helpers -----------------------------------------------------
     def _build_layout(self) -> None:
@@ -31,6 +54,8 @@ class MetaboGUI:
 
         self.chat = ScrolledText(left_frame, state=tk.DISABLED, wrap=tk.WORD)
         self.chat.pack(fill=tk.BOTH, expand=True)
+        self.chat.tag_config("user", foreground="blue")
+        self.chat.tag_config("system", foreground="green")
 
         input_frame = tk.Frame(left_frame)
         input_frame.pack(fill=tk.X)
@@ -54,6 +79,7 @@ class MetaboGUI:
         self._build_emotion_tab()
         self._build_graph_tab()
         self._build_log_tab()
+        self._build_takt_tab()
 
     def _build_goals_tab(self) -> None:
         frame = ttk.Frame(self.notebook)
@@ -106,6 +132,27 @@ class MetaboGUI:
         self.log_box.pack(fill=tk.BOTH, expand=True)
         self._load_log()
 
+    def _build_takt_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Metabotakt")
+
+        run_btn = tk.Button(frame, text="Takt ausführen", command=self._run_takt)
+        run_btn.pack(pady=5)
+
+        self.takt_goal_var = tk.StringVar(value="-")
+        self.takt_emotion_var = tk.StringVar(value="-")
+        self.takt_delta_var = tk.StringVar(value="0")
+
+        tk.Label(frame, textvariable=self.takt_goal_var, wraplength=200).pack(anchor=tk.W)
+        tk.Label(frame, text="Emotion:").pack(anchor=tk.W)
+        tk.Label(frame, textvariable=self.takt_emotion_var).pack(anchor=tk.W)
+        tk.Label(frame, text="Δ-Entropie:").pack(anchor=tk.W)
+        tk.Label(frame, textvariable=self.takt_delta_var).pack(anchor=tk.W)
+
+        tk.Label(frame, text="Reflexion:").pack(anchor=tk.W, pady=(10, 0))
+        self.takt_reflection = ScrolledText(frame, height=5, state=tk.DISABLED)
+        self.takt_reflection.pack(fill=tk.BOTH, expand=True)
+
     # Button actions -----------------------------------------------------
     def _set_goal(self, goal: str) -> None:
         goal = goal.strip()
@@ -113,7 +160,7 @@ class MetaboGUI:
             return
         set_goal(goal)
         self.goal_var.set(goal)
-        self._append_chat(f"[Neues Ziel gesetzt: {goal}]\n")
+        self._append_chat(f"[Neues Ziel gesetzt: {goal}]\n", "system")
 
     def _on_send(self, event=None) -> None:  # type: ignore[override]
         user_input = self.entry.get().strip()
@@ -121,9 +168,9 @@ class MetaboGUI:
             return
         self.entry.delete(0, tk.END)
 
-        self._append_chat(f"Du: {user_input}\n")
+        self._append_chat(f"Du: {user_input}\n", "user")
         result = run_metabo_cycle(user_input)
-        self._append_chat(f"System: {result['reflection']}\n")
+        self._append_chat(f"System: {result['reflection']}\n", "system")
         self.chat.see(tk.END)
 
         # Update tabs
@@ -135,10 +182,31 @@ class MetaboGUI:
         self._update_triplets(result.get('triplets', []))
         self._load_log()
 
+    def _run_takt(self) -> None:
+        result = run_metabotakt()
+        self.goal_var.set(result["goal"])
+        msg = result.get("goal_update", "")
+        if msg:
+            self._append_chat(f"[{msg}]\n", "system")
+            self.takt_goal_var.set(msg)
+        else:
+            self.takt_goal_var.set(result["goal"])
+
+        self.takt_emotion_var.set(f"{result['emotion']} ({result['intensity']})")
+        self.takt_delta_var.set(f"{result['delta']:+.2f}")
+        self.takt_reflection.configure(state=tk.NORMAL)
+        self.takt_reflection.delete("1.0", tk.END)
+        self.takt_reflection.insert(tk.END, result["reflection"])
+        self.takt_reflection.configure(state=tk.DISABLED)
+        self._load_log()
+
     # Update helpers ----------------------------------------------------
-    def _append_chat(self, text: str) -> None:
+    def _append_chat(self, text: str, tag: str = "") -> None:
         self.chat.configure(state=tk.NORMAL)
-        self.chat.insert(tk.END, text)
+        if tag:
+            self.chat.insert(tk.END, text, tag)
+        else:
+            self.chat.insert(tk.END, text)
         self.chat.configure(state=tk.DISABLED)
 
     def _update_subgoals(self, subgoals: list[str]) -> None:
@@ -178,10 +246,13 @@ class MetaboGUI:
 
     def _show_graph(self) -> None:
         try:
-            from memory.graph_manager import GraphManager
-            G = GraphManager().graph
+            from memory_manager import get_memory_manager
+            G = get_memory_manager().graph.graph
         except Exception as exc:  # pragma: no cover - visualisation is optional
-            self._append_chat(f"[Graph konnte nicht geladen werden: {exc}]\n")
+            self._append_chat(
+                f"[Graph konnte nicht geladen werden: {exc}]\n",
+                "system",
+            )
             return
 
         win = tk.Toplevel(self.root)
@@ -192,6 +263,19 @@ class MetaboGUI:
             rel = data.get('relation', '')
             text.insert(tk.END, f"{u} --{rel}--> {v}\n")
         text.configure(state=tk.DISABLED)
+
+    def _save_graph(self) -> None:
+        """Persist the knowledge graph and notify the user."""
+        try:
+            self.memory.graph.save_graph()
+            self._append_chat("[Graph gespeichert]\n", "system")
+        except Exception as exc:  # pragma: no cover - error handling
+            self._append_chat(f"[Fehler beim Speichern: {exc}]\n", "system")
+
+    def _on_close(self) -> None:
+        """Save graph on window close."""
+        self._save_graph()
+        self.root.destroy()
 
     # Public API --------------------------------------------------------
     def run(self) -> None:

--- a/llm_client.py
+++ b/llm_client.py
@@ -1,0 +1,34 @@
+"""Shared OpenAI client utilities."""
+from __future__ import annotations
+
+import os
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    openai = None
+
+_CLIENT = None
+
+
+def get_client(api_key: str | None = None):
+    """Return a cached OpenAI client or ``None`` if unavailable."""
+    global _CLIENT
+    if openai is None:
+        return None
+    if _CLIENT is None:
+        key = api_key or os.getenv("OPENAI_API_KEY")
+        if not key:
+            return None
+        if hasattr(openai, "OpenAI"):
+            _CLIENT = openai.OpenAI(api_key=key)
+        else:
+            openai.api_key = key
+            _CLIENT = openai
+    return _CLIENT
+
+
+
+def init_client() -> None:
+    """Initialize the global client if possible."""
+    get_client(os.getenv("OPENAI_API_KEY"))

--- a/main.py
+++ b/main.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 from control.metabo_cycle import run_metabo_cycle
-from goals.goal_manager import set_goal, get_active_goal
+from control.takt_engine import run_metabotakt
+from goals.goal_manager import set_goal
+from goals.goal_updater import update_goal
 from interface.metabo_gui import MetaboGUI
+import llm_client
+from memory_manager import get_memory_manager
 
 
 def print_help() -> None:
@@ -33,6 +37,14 @@ def main() -> None:
         if user_input == "/hilfe":
             print_help()
             continue
+        if user_input == "/takt":
+            result = run_metabotakt()
+            print("[Metabotakt ausgeführt]")
+            if result["goal_update"]:
+                print(result["goal_update"])
+            print(f"ΔE: {result['delta']:+.2f} -> {result['emotion']} ({result['intensity']})")
+            print(f"Reflexion: {result['reflection']}")
+            continue
         if user_input.startswith("/ziel"):
             new_goal = user_input[len("/ziel"):].strip()
             if not new_goal:
@@ -43,8 +55,15 @@ def main() -> None:
             continue
 
         result = run_metabo_cycle(user_input)
+        new_goal = update_goal(
+            user_input=user_input,
+            last_goal=result.get("goal", ""),
+            last_reflection=result.get("reflection", ""),
+            triplets=result.get("triplets", []),
+        )
+        set_goal(new_goal)
         print("[Zyklus abgeschlossen]")
-        print(f"Ziel: {result['goal']}")
+        print(f"Aktuelles Ziel: {new_goal}")
         print(f"Antwort: {result['reflection']}")
         print(f"Emotion: {result['emotion']} (Δ={result['delta']:+.2f})")
         if result['triplets']:
@@ -52,5 +71,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    llm_client.init_client()
+    get_memory_manager()
     gui = MetaboGUI()
     gui.run()

--- a/memory/intention_graph.py
+++ b/memory/intention_graph.py
@@ -1,18 +1,29 @@
 
 import os
+from pathlib import Path
 from typing import List, Tuple
 
 import networkx as nx
-import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
 
 class IntentionGraph:
-    """Graph storing intention triples with persistent GML saving."""
+    """Graph storing intention triples and goal transitions with persistence."""
 
-    def __init__(self, filepath: str = "data/graph.gml"):
-        """Load existing graph from ``filepath`` or create a new one."""
+    def __init__(self, filepath: str = "data/graph.gml", goal_path: str | None = None):
+        """Load existing graphs or create new ones.
+
+        Parameters
+        ----------
+        filepath:
+            Path to the knowledge graph file used for triplets.
+        goal_path:
+            Path to the directed goal graph. Defaults to ``memory/intent_graph.gml``.
+        """
+
         self.filepath = filepath
+        self.goal_path = Path(goal_path or "memory/intent_graph.gml")
         self.load_graph()
+        self._load_goal_graph()
 
     def load_graph(self):
         """Load the graph from ``self.filepath`` if it exists."""
@@ -37,6 +48,27 @@ class IntentionGraph:
         except Exception as exc:
             print(f"[Graph] Fehler beim Speichern: {exc}")
 
+    def _load_goal_graph(self) -> None:
+        """Load the directed goal graph from ``self.goal_path`` if available."""
+        if self.goal_path.exists():
+            try:
+                self.goal_graph = nx.read_gml(self.goal_path)
+                if not isinstance(self.goal_graph, nx.DiGraph):
+                    self.goal_graph = nx.DiGraph(self.goal_graph)
+                print(f"[GoalGraph] Lade bestehenden Graph aus {self.goal_path}")
+            except Exception as exc:  # pragma: no cover - log for debugging
+                print(f"[GoalGraph] Fehler beim Laden, erstelle neuen Graph: {exc}")
+                self.goal_graph = nx.DiGraph()
+        else:
+            self.goal_graph = nx.DiGraph()
+
+    def _save_goal_graph(self) -> None:
+        """Persist the goal graph to disk."""
+        try:
+            nx.write_gml(self.goal_graph, self.goal_path)
+        except Exception as exc:  # pragma: no cover - log for debugging
+            print(f"[GoalGraph] Fehler beim Speichern: {exc}")
+
 
     def add_triplets(self, triplets: List[Tuple[str, str, str]]):
         """Add a list of (subject, relation, object) triples to the graph."""
@@ -48,6 +80,45 @@ class IntentionGraph:
     def snapshot(self) -> nx.MultiDiGraph:
         """Return a copy of the current graph."""
         return self.graph.copy()
+
+    # ------------------------------------------------------------------
+    # Goal transition management
+
+    def add_goal_transition(self, previous_goal: str, new_goal: str) -> None:
+        """Add a directed edge from ``previous_goal`` to ``new_goal``.
+
+        Nodes are created if they do not yet exist. Duplicate edges are
+        ignored. The goal graph is persisted after modification.
+        """
+
+        self.goal_graph.add_node(previous_goal)
+        self.goal_graph.add_node(new_goal)
+        if not self.goal_graph.has_edge(previous_goal, new_goal):
+            self.goal_graph.add_edge(previous_goal, new_goal)
+            self._save_goal_graph()
+
+    def get_goal_path(self) -> List[str]:
+        """Return a list representing the current goal path."""
+
+        if len(self.goal_graph) == 0:
+            return []
+        try:
+            return list(nx.topological_sort(self.goal_graph))
+        except nx.NetworkXUnfeasible:
+            start = next(iter(self.goal_graph.nodes()))
+            return list(nx.dfs_preorder_nodes(self.goal_graph, start))
+
+    def visualize_graph(self, output_path: str = "memory/intent_graph.png") -> None:
+        """Create a simple PNG visualization of the goal graph."""
+
+        import matplotlib.pyplot as plt
+
+        plt.figure(figsize=(8, 6))
+        pos = nx.spring_layout(self.goal_graph)
+        nx.draw(self.goal_graph, pos, with_labels=True, arrows=True, node_color="lightblue")
+        plt.tight_layout()
+        plt.savefig(output_path)
+        plt.close()
 
 
 def expand_target_neighborhood(
@@ -82,4 +153,5 @@ def expand_target_neighborhood(
 
     ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
     return [n for n, _ in ranked[:top_k]]
+
 

--- a/memory/recall_context.py
+++ b/memory/recall_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List, Dict
 import networkx as nx
 
-from memory.intention_graph import IntentionGraph
+from memory_manager import get_memory_manager
 from goals.goal_manager import get_active_goal
 
 
@@ -30,8 +30,7 @@ def recall_context(limit: int = 10, scope: str = "global") -> List[Dict[str, str
         value returns a global selection of edges ordered by node degree.
     """
 
-    ig = IntentionGraph()
-    G: nx.MultiDiGraph = ig.graph
+    G: nx.MultiDiGraph = get_memory_manager().graph.graph
 
     edges: List[tuple] = []
     if scope == "goal":

--- a/memory_manager.py
+++ b/memory_manager.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+from memory.intention_graph import IntentionGraph
+from reasoning.entropy_analyzer import entropy_of_graph
+from reasoning.emotion import interpret_emotion
+
+
+class MemoryManager:
+    """Handle graph updates and store reflections and emotions."""
+
+    def __init__(
+        self,
+        graph_path: str = "data/graph.gml",
+        emotion_log: str = "data/emotions.jsonl",
+        reflection_path: str = "memory/last_reflection.txt",
+        entropy_path: str = "memory/last_entropy.txt",
+    ) -> None:
+        self.graph = IntentionGraph(graph_path)
+        self.emotion_log = Path(emotion_log)
+        self.emotion_log.parent.mkdir(parents=True, exist_ok=True)
+        self.reflection_path = Path(reflection_path)
+        self.reflection_path.parent.mkdir(parents=True, exist_ok=True)
+        self.entropy_path = Path(entropy_path)
+        self.entropy_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Triplet handling
+
+    def store_triplets(self, triplets: List[Tuple[str, str, str]]) -> tuple[float, float]:
+        """Add ``triplets`` to the intention graph and return entropy values."""
+        before = entropy_of_graph(self.graph.snapshot())
+        if triplets:
+            self.graph.add_triplets(triplets)
+        after = entropy_of_graph(self.graph.snapshot())
+        return before, after
+
+    # ------------------------------------------------------------------
+    # Reflection persistence
+
+    def store_reflection(self, reflection: str) -> None:
+        """Persist the latest reflection text."""
+        self.reflection_path.write_text(reflection, encoding="utf-8")
+
+    def load_reflection(self) -> str:
+        """Return the last saved reflection."""
+        try:
+            return self.reflection_path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    # ------------------------------------------------------------------
+    # Emotion logging
+
+    def save_emotion(self, ent_before: float, ent_after: float) -> dict:
+        """Interpret and store the emotion derived from entropy change."""
+        emo = interpret_emotion(ent_before, ent_after)
+        record = {
+            "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+            "entropy_before": ent_before,
+            "entropy_after": ent_after,
+            **emo,
+        }
+        with self.emotion_log.open("a", encoding="utf-8") as fh:
+            json.dump(record, fh, ensure_ascii=False)
+            fh.write("\n")
+        return emo
+
+    # ------------------------------------------------------------------
+    # Entropy helpers
+
+    def calculate_entropy(self) -> float:
+        """Return the entropy of the current knowledge graph."""
+        return entropy_of_graph(self.graph.snapshot())
+
+    def load_last_entropy(self) -> float:
+        """Return the previously stored entropy value."""
+        try:
+            return float(self.entropy_path.read_text())
+        except (FileNotFoundError, ValueError):
+            return 0.0
+
+    def store_last_entropy(self, value: float) -> None:
+        """Persist the latest entropy value for future deltas."""
+        self.entropy_path.write_text(str(value))
+
+    def map_entropy_to_emotion(self, delta: float) -> dict:
+        """Map an entropy delta to an emotion assessment."""
+        if delta <= -0.05:
+            emotion = "positive"
+        elif delta >= 0.05:
+            emotion = "negative"
+        else:
+            emotion = "neutral"
+
+        abs_delta = abs(delta)
+        if abs_delta < 0.05:
+            intensity = "low"
+        elif abs_delta <= 0.15:
+            intensity = "medium"
+        else:
+            intensity = "high"
+
+        return {"delta": delta, "emotion": emotion, "intensity": intensity}
+
+# ------------------------------------------------------------------
+# Global memory instance handling
+
+_default_manager: MemoryManager | None = None
+
+
+def get_memory_manager() -> MemoryManager:
+    """Return a shared :class:`MemoryManager` instance."""
+    global _default_manager
+    if _default_manager is None:
+        _default_manager = MemoryManager()
+    return _default_manager
+

--- a/metabo_cycle.py
+++ b/metabo_cycle.py
@@ -4,27 +4,52 @@ import logging
 from typing import Dict
 
 from goal_manager import GoalManager
-from graph_manager import GraphManager
+from goals.goal_updater import propose_goal, check_goal_shift
+from memory_manager import get_memory_manager
 from context_selector import load_context
 from triplet_parser_llm import extract_triplets_via_llm
+from recall_context import recall_context
 from reflection.reflection_engine import generate_reflection
 from logs.logger import MetaboLogger
 from reasoning.emotion import interpret_emotion
 from reasoning.entropy_analyzer import entropy_of_graph
 from subgoal_planner import decompose_goal
 from subgoal_executor import execute_first_subgoal
+from difflib import SequenceMatcher
 
 logger = logging.getLogger(__name__)
+
+
+def is_new_topic(user_input: str, current_goal: str) -> bool:
+    """Return True if ``user_input`` does not relate to ``current_goal``."""
+    if not user_input or not current_goal:
+        return False
+    prefix = user_input.lower().strip()[:25]
+    return prefix not in current_goal.lower()
 
 
 def run_metabo_cycle(user_input: str) -> Dict[str, object]:
     """Execute one MetaboMind cycle and return a structured result."""
     goal_mgr = GoalManager()
-    graph_mgr = GraphManager()
+    memory = get_memory_manager()
     log = MetaboLogger()
 
     goal = goal_mgr.get_goal()
     last_reflection = goal_mgr.load_reflection()
+
+    proposed = propose_goal(user_input)
+    if not proposed and is_new_topic(user_input, goal):
+        proposed = user_input.strip()
+
+    if proposed and check_goal_shift(goal, proposed):
+        if goal:
+            memory.graph.add_goal_transition(goal, proposed)
+        else:
+            memory.graph.goal_graph.add_node(proposed)
+            memory.graph._save_goal_graph()
+        goal_mgr.set_goal(proposed)
+        logger.info("Neues Ziel erkannt: %s -> %s", goal, proposed)
+        goal = proposed
 
     try:
         subgoals = decompose_goal(goal, last_reflection)
@@ -33,24 +58,31 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
         subgoals = [goal]
     goal = execute_first_subgoal(goal, subgoals)
 
-    graph_snapshot = graph_mgr.snapshot()
+    graph_snapshot = memory.graph.snapshot()
     entropy_before = entropy_of_graph(graph_snapshot)
 
     try:
-        context_nodes = load_context(graph_mgr.graph, goal)
+        context_nodes = load_context(memory.graph.graph, goal)
     except Exception as exc:
         logger.warning("context selection failed: %s", exc)
         context_nodes = []
 
-    prompt = (
-        f"Ziel: {goal}\n"\
-        f"Eingabe: {user_input}\n"\
-        f"Kontext: {', '.join(context_nodes)}\n"\
-        f"Letzte Reflexion: {last_reflection}"
-    )
+    try:
+        mem_facts = recall_context(scope="goal", limit=5)
+        fact_triplets = [
+            (d["subject"], d["predicate"], d["object"]) for d in mem_facts
+        ]
+    except Exception as exc:
+        logger.warning("context recall failed: %s", exc)
+        fact_triplets = []
 
     try:
-        reflection_data = generate_reflection(prompt)
+        reflection_data = generate_reflection(
+            last_user_input=user_input,
+            goal=goal,
+            last_reflection=last_reflection,
+            triplets=fact_triplets,
+        )
         reflection_text = reflection_data.get("reflection", "")
     except Exception as exc:
         logger.warning("reflection generation failed: %s", exc)
@@ -65,17 +97,14 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
 
     if triplets:
         try:
-            graph_mgr.add_triplets(triplets)
+            memory.graph.add_triplets(triplets)
         except Exception as exc:
             logger.warning("graph update failed: %s", exc)
 
-    entropy_after = entropy_of_graph(graph_mgr.snapshot())
+    entropy_after = entropy_of_graph(memory.graph.snapshot())
     emotion = interpret_emotion(entropy_before, entropy_after)
 
-    try:
-        graph_mgr.save()
-    except Exception as exc:
-        logger.warning("graph save failed: %s", exc)
+
 
     try:
         log.log_cycle(

--- a/recall_context.py
+++ b/recall_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List, Dict
 import networkx as nx
 
-from memory.intention_graph import IntentionGraph
+from memory_manager import get_memory_manager
 from goal_manager import get_active_goal
 
 
@@ -30,8 +30,7 @@ def recall_context(limit: int = 10, scope: str = "global") -> List[Dict[str, str
         value returns a global selection of edges ordered by node degree.
     """
 
-    ig = IntentionGraph()
-    G: nx.MultiDiGraph = ig.graph
+    G: nx.MultiDiGraph = get_memory_manager().graph.graph
 
     edges: List[tuple] = []
     if scope == "goal":

--- a/reflection/reflection_engine.py
+++ b/reflection/reflection_engine.py
@@ -1,84 +1,201 @@
 import os
-from typing import Dict, List, Tuple
+import json
+import logging
+from typing import Dict, List, Tuple, Optional
 
-from utils.json_utils import parse_json_safe
-
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from llm_client import get_client
+from goals import goal_manager
+from memory_manager import get_memory_manager
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
 
 from control.metabo_rules import METABO_RULES
 
 
-def generate_reflection(text: str, api_key: str | None = None) -> Dict[str, object]:
-    """Generate a reflection over the given text.
+logger = logging.getLogger(__name__)
 
-    Parameters
-    ----------
-    text: str
-        Input statement or generated output of the LLM.
-    api_key: str | None
-        Optional API key for OpenAI. If omitted and no ``OPENAI_API_KEY``
-        environment variable exists, a simple offline reflection is returned.
 
-    Returns
-    -------
-    dict
-        Dictionary with keys ``reflection`` (improved text), ``explanation``
-        describing the improvement and optional ``triplets`` listing semantic
-        triples as ``(subject, predicate, object)`` tuples.
-    """
-    key = api_key or os.getenv("OPENAI_API_KEY")
-    if not key or openai is None:
+def run_llm_task(prompt: str, api_key: str | None = None) -> str:
+    """Execute a simple LLM chat completion and return the text."""
+    client = get_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        return ""
+
+    messages = [{"role": "user", "content": prompt}]
+
+    try:
+        if hasattr(client, "chat"):
+            resp = client.chat.completions.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+            )
+            return resp.choices[0].message.content.strip()
+        resp = client.ChatCompletion.create(
+            model=MODELS['chat'],
+            temperature=TEMPERATURES['chat'],
+            messages=messages,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+    except Exception:  # pragma: no cover - network errors
+        return ""
+
+
+def detect_goal_shift(
+    user_input: str,
+    current_goal: str,
+    api_key: str | None = None,
+    previous_user_inputs: list[str] | None = None,
+    last_system_output: str = "",
+) -> tuple[bool, Optional[str]]:
+    """Return ``(change_goal, new_goal)`` based on conversation context."""
+    client = get_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        return False, None
+
+    previous_user_inputs = previous_user_inputs or []
+
+    system = PROMPTS['goal_detector_system']
+
+    parts = [f"Aktuelles Ziel: {current_goal}"]
+    if previous_user_inputs:
+        recent = ' | '.join(previous_user_inputs[-2:])
+        parts.append(f"Vorherige Nutzereingaben: {recent}")
+    if last_system_output.strip():
+        parts.append(f"Letzte Systemantwort: {last_system_output.strip()}")
+    parts.append(f"Eingabe: {user_input}")
+    user = "\n".join(parts)
+
+    functions = [
+        {
+            "name": "goal_decision",
+            "description": "Entscheidet, ob ein neues Ziel vorgeschlagen wird",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "change_goal": {"type": "boolean"},
+                    "new_goal": {"type": "string"},
+                },
+                "required": ["change_goal"],
+            },
+        }
+    ]
+
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+    try:
+        if hasattr(client, "chat"):
+            resp = client.chat.completions.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp.choices[0]
+            if choice.finish_reason == "function_call":
+                fc = choice.message.function_call
+                if fc and fc.name == "goal_decision":
+                    data = json.loads(fc.arguments)
+                    return data.get("change_goal", False), data.get("new_goal")
+        else:
+            resp = client.ChatCompletion.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call="auto",
+            )
+            choice = resp["choices"][0]
+            if choice.get("finish_reason") == "function_call":
+                fc = choice["message"]["function_call"]
+                if fc["name"] == "goal_decision":
+                    data = json.loads(fc["arguments"])
+                    return data.get("change_goal", False), data.get("new_goal")
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("goal detection failed: %s", exc)
+
+    return False, None
+
+def generate_reflection(
+    last_user_input: str,
+    goal: str,
+    last_reflection: str,
+    triplets: List[Tuple[str, str, str]] | None = None,
+    api_key: str | None = None,
+    previous_user_inputs: list[str] | None = None,
+    last_system_output: str = "",
+) -> Dict[str, object]:
+    """Generate a short reflection addressing the user input and goal."""
+
+    client = get_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
         return {
-            "reflection": text,
-            "explanation": "Kein OpenAI API-Schlüssel vorhanden; Eingabe unverändert.",
+            "reflection": last_user_input,
+            "explanation": "Kein OpenAI API-Schl\u00fcssel vorhanden; Eingabe unver\u00e4ndert.",
             "triplets": [],
         }
 
-    system_prompt = (
-        METABO_RULES
-        + (
-            "\nDu bist ein Denkagent in einem KI-System namens MetaboMind. "
-            "Deine Aufgabe ist es, auf eine Nutzereingabe im Kontext eines Ziels "
-            "zu antworten. Sprich dabei direkt zum Nutzer – nicht über die Eingabe. "
-            "Formuliere eine neue Aussage, die dem Ziel näherkommt. Nutze dein "
-            "vorhandenes Wissen und die letzte Reflexion, wenn sie dir hilft. "
-            "Antworte in einem einzigen natürlichen Satz. Keine Meta-Analyse, "
-            "keine Wiederholung des Ziels."
-        )
-    )
+    if not goal.strip():
+        goal = f"Erkundung: {last_user_input.strip()[:40]}"
 
-    if hasattr(openai, "OpenAI"):
-        client = openai.OpenAI(api_key=key)
+    changed, proposed = detect_goal_shift(
+        last_user_input,
+        goal,
+        api_key=api_key,
+        previous_user_inputs=previous_user_inputs,
+        last_system_output=last_system_output,
+    )
+    goal_update_msg = ""
+    memory = get_memory_manager()
+    if changed and proposed and proposed.strip() and proposed != goal:
+        logger.info("Neues Ziel erkannt: %s -> %s", goal, proposed)
+        if goal:
+            memory.graph.add_goal_transition(goal, proposed)
+        else:
+            memory.graph.goal_graph.add_node(proposed)
+            memory.graph._save_goal_graph()
+        goal_manager.set_goal(proposed)
+        goal_update_msg = run_llm_task(
+            f"Reflektiere kurz den Zielwechsel von '{goal}' zu '{proposed}'.",
+            api_key=api_key,
+        )
+        goal = proposed
+
+    facts = "; ".join([f"{s} {p} {o}" for s, p, o in triplets or []])
+
+    system_prompt = METABO_RULES + "\n" + PROMPTS['reflection_system']
+
+    user_content = f"Ziel: {goal}\nEingabe: {last_user_input}"
+    if last_reflection.strip():
+        user_content += f"\nLetzte Reflexion: {last_reflection.strip()}"
+    if facts:
+        user_content += f"\nTripel: {facts}"
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_content},
+    ]
+
+    if hasattr(client, "chat"):
         response = client.chat.completions.create(
-            model="gpt-4o",
-            temperature=0,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": text},
-            ],
+            model=MODELS['chat'],
+            temperature=TEMPERATURES['chat'],
+            messages=messages,
         )
         content = response.choices[0].message.content
     else:
-        openai.api_key = key
-        response = openai.ChatCompletion.create(
-            model="gpt-4o",
-            temperature=0,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": text},
-            ],
+        response = client.ChatCompletion.create(
+            model=MODELS['chat'],
+            temperature=TEMPERATURES['chat'],
+            messages=messages,
         )
         content = response["choices"][0]["message"]["content"]
-    data = parse_json_safe(content)
-    if isinstance(data, dict):
-        if "triplets" in data and isinstance(data["triplets"], list):
-            data["triplets"] = [tuple(t) for t in data["triplets"]]
-        return data
+
     return {
         "reflection": content.strip(),
-        "explanation": "Antwort nicht im JSON-Format parsbar.",
+        "explanation": goal_update_msg,
         "triplets": [],
     }

--- a/subgoal_planner.py
+++ b/subgoal_planner.py
@@ -6,36 +6,25 @@ import logging
 import os
 
 from utils.json_utils import parse_json_safe
-
-try:
-    import openai  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    openai = None
+from llm_client import get_client
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
 
 logger = logging.getLogger(__name__)
 
-_SYSTEM_PROMPT = (
-    "Du bist ein Planungsagent in einem KI-System namens MetaboMind. "
-    "Zerlege das folgende Ziel in 2 bis 5 umsetzbare Teilziele. "
-    "Formuliere jedes Teilziel als kurzen Satz im Klartext. "
-    "Gib eine JSON-Liste der Teilziele zur\xFCck."
-)
+_SYSTEM_PROMPT = PROMPTS['subgoal_planner_system']
 
 
 def decompose_goal(
     goal: str,
     context: str = "",
     *,
-    model: str = "gpt-4o-mini",
-    temperature: float = 0.3,
+    model: str = MODELS['subgoal'],
+    temperature: float = TEMPERATURES['subgoal'],
 ) -> List[str]:
     """Return a list of subgoals decomposed from ``goal``."""
-    if openai is None:
-        raise ImportError("openai package not installed")
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise EnvironmentError("OPENAI_API_KEY not set")
+    client = get_client(os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        raise EnvironmentError("OPENAI_API_KEY not set or client unavailable")
 
     user_content = f"Ziel: {goal}"
     if context:
@@ -47,8 +36,7 @@ def decompose_goal(
     ]
 
     try:
-        if hasattr(openai, "OpenAI"):
-            client = openai.OpenAI(api_key=api_key)
+        if hasattr(client, "chat"):
             response = client.chat.completions.create(
                 model=model,
                 temperature=temperature,
@@ -56,8 +44,7 @@ def decompose_goal(
             )
             text = response.choices[0].message.content
         else:
-            openai.api_key = api_key
-            response = openai.ChatCompletion.create(
+            response = client.ChatCompletion.create(
                 model=model,
                 temperature=temperature,
                 messages=messages,
@@ -72,7 +59,7 @@ def decompose_goal(
     if isinstance(data, list) and all(isinstance(s, str) for s in data):
         subgoals = [s.strip() for s in data if s.strip()]
     else:
-        lines = [l.strip("-•* \t") for l in text.splitlines() if l.strip()]
+        lines = [line.strip("-•* \t") for line in text.splitlines() if line.strip()]
         if 2 <= len(lines) <= 5:
             subgoals = lines
 

--- a/tests/test_cycle_controller.py
+++ b/tests/test_cycle_controller.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import types
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from control import cycle_controller

--- a/tests/test_cycle_manager.py
+++ b/tests/test_cycle_manager.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from control.cycle_manager import CycleManager
+
+
+def setup_common(monkeypatch, cm):
+    monkeypatch.setattr(cm.memory.graph, "_save_goal_graph", lambda: None)
+    monkeypatch.setattr(cm.memory.graph, "save_graph", lambda: None)
+    monkeypatch.setattr("control.cycle_manager.extract_triplets_via_llm", lambda text: [])
+    monkeypatch.setattr("control.cycle_manager.generate_reflection", lambda **k: {"reflection": ""})
+    monkeypatch.setattr(cm.memory, "save_emotion", lambda *a, **k: {"delta": 0.0, "emotion": "neutral", "intensity": "low"})
+    monkeypatch.setattr(cm.memory, "store_reflection", lambda text: None)
+
+
+def test_goal_switch(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr(
+        "control.cycle_manager.goal_engine.update_goal",
+        lambda user_input, last_reflection, triplets: "Neu",
+    )
+    cm.current_goal = "Alt"
+    res = cm.run_cycle("irgendwas")
+    assert cm.current_goal == "Neu"
+    assert res["goal"] == "Neu"
+    assert "Neues Ziel" in res["goal_update"]
+
+
+def test_no_goal_switch(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr(
+        "control.cycle_manager.goal_engine.update_goal",
+        lambda *args, **kw: cm.current_goal,
+    )
+    cm.current_goal = "Alt"
+    res = cm.run_cycle("etwas")
+    assert cm.current_goal == "Alt"
+    assert res["goal_update"] == ""
+
+
+def test_first_goal(monkeypatch):
+    cm = CycleManager(api_key=None, logger=None)
+    setup_common(monkeypatch, cm)
+    monkeypatch.setattr(
+        "control.cycle_manager.goal_engine.update_goal",
+        lambda *args, **kw: "Start",
+    )
+    cm.current_goal = ""
+    res = cm.run_cycle("hey")
+    assert cm.current_goal == "Start"
+    assert res["goal"] == "Start"
+    assert "Neues Ziel" in res["goal_update"]

--- a/tests/test_detect_goal_shift.py
+++ b/tests/test_detect_goal_shift.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import json
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from reflection import reflection_engine
+
+
+def test_detect_goal_shift_context(monkeypatch):
+    messages_store = {}
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self.create)
+            )
+
+        def create(self, *args, **kwargs):
+            messages_store['messages'] = kwargs.get('messages')
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(
+                    finish_reason="function_call",
+                    message=types.SimpleNamespace(
+                        function_call=types.SimpleNamespace(
+                            name="goal_decision",
+                            arguments=json.dumps({"change_goal": True, "new_goal": "Musik"})
+                        )
+                    )
+                )]
+            )
+
+    monkeypatch.setattr(reflection_engine, "get_client", lambda *a, **k: DummyClient())
+
+    change, goal = reflection_engine.detect_goal_shift(
+        "lass uns über Musik reden",
+        "Sport",
+        previous_user_inputs=["Hallo", "Das interessiert mich nicht"],
+        last_system_output="Ok"
+    )
+
+    assert change is True
+    assert goal == "Musik"
+    joined = "\n".join(m['content'] for m in messages_store['messages'])
+    assert "Das interessiert mich nicht" in joined
+    assert "Ok" in joined

--- a/tests/test_goal_selector.py
+++ b/tests/test_goal_selector.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from goals import goal_updater as goal_selector
+from goals.goal_manager import GoalManager
+from memory.intention_graph import IntentionGraph
+
+
+def test_propose_goal_no_openai(monkeypatch):
+    monkeypatch.setattr(goal_selector, "get_client", lambda *a, **k: None)
+    assert goal_selector.propose_goal("hi") is None
+
+
+def test_check_goal_shift_basic(monkeypatch):
+    monkeypatch.setattr(goal_selector, "get_client", lambda *a, **k: None)
+    assert goal_selector.check_goal_shift("A", "B")
+    assert not goal_selector.check_goal_shift("Goal", "Goal")
+
+
+def test_apply_goal_shift(tmp_path, monkeypatch):
+    gm = GoalManager(path=str(tmp_path / "goal.txt"))
+    ig = IntentionGraph(filepath=str(tmp_path / "g.gml"))
+    called = {}
+    monkeypatch.setattr(ig, "add_goal_transition", lambda a, b: called.setdefault("edge", (a, b)))
+    goal_selector.apply_goal_shift("Old", "New", gm, ig)
+    assert gm.get_goal() == "New"
+    assert called["edge"] == ("Old", "New")

--- a/tests/test_goal_updater.py
+++ b/tests/test_goal_updater.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from goals import goal_updater
+
+
+def test_missing_openai(monkeypatch):
+    monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: None)
+    res = goal_updater.update_goal("hi", "old", "", [])
+    assert res == "old"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: None)
+    res = goal_updater.update_goal("hi", "old", "", [])
+    assert res == "old"
+
+
+def test_new_goal(monkeypatch):
+    class Dummy:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self.create)
+            )
+
+        def create(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="Untersuche X"), finish_reason=None)]
+            )
+
+    monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: Dummy())
+    res = goal_updater.update_goal("frage", "Alt", "", [])
+    assert res == "Untersuche X"
+
+
+def test_explicit_command(monkeypatch):
+    monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: None)
+    res = goal_updater.update_goal("Beschäftige dich mit Z", "Alt", "", [])
+    assert res == "Z"
+
+
+def test_proposed_goal_via_llm(monkeypatch):
+    monkeypatch.setattr(goal_updater, "_extract_explicit_goal", lambda t: None)
+    monkeypatch.setattr(goal_updater, "propose_goal", lambda t: "Neu")
+    monkeypatch.setattr(goal_updater, "check_goal_shift", lambda a, b: True)
+    monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: None)
+    res = goal_updater.update_goal("hi", "Alt", "", [])
+    assert res == "Neu"
+
+
+def test_config_prompt():
+    from cfg import config
+    assert goal_updater._SYSTEM_PROMPT is config.PROMPTS['goal_updater_system']
+

--- a/tests/test_metabo_cycle.py
+++ b/tests/test_metabo_cycle.py
@@ -1,0 +1,50 @@
+import os
+import os
+import sys
+import types
+import networkx as nx
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from control import metabo_cycle
+
+
+def setup(monkeypatch, tmp_path, goal=""):
+    class DummyGraph:
+        def __init__(self):
+            self.goal_graph = nx.DiGraph()
+        def snapshot(self):
+            return nx.MultiDiGraph()
+        def add_triplets(self, t):
+            pass
+        def add_goal_transition(self, a, b):
+            self.goal_graph.add_edge(a, b)
+        def _save_goal_graph(self):
+            pass
+
+    mem = types.SimpleNamespace(graph=DummyGraph())
+    monkeypatch.setattr(metabo_cycle, "get_memory_manager", lambda: mem)
+    monkeypatch.setattr(metabo_cycle, "MetaboLogger", lambda *a, **k: types.SimpleNamespace(log_cycle=lambda **kw: None))
+    monkeypatch.setattr(metabo_cycle, "decompose_goal", lambda g, r: [g])
+    monkeypatch.setattr(metabo_cycle, "execute_first_subgoal", lambda g, s: g)
+    monkeypatch.setattr(metabo_cycle, "load_context", lambda g, goal: [])
+    monkeypatch.setattr(metabo_cycle, "recall_context", lambda scope="goal", limit=5: [])
+    monkeypatch.setattr(metabo_cycle, "generate_reflection", lambda **k: {"reflection": ""})
+    monkeypatch.setattr(metabo_cycle, "extract_triplets_via_llm", lambda text: [])
+
+    path = tmp_path / "goal.txt"
+    refl = tmp_path / "ref.txt"
+    class DummyGM(metabo_cycle.GoalManager):
+        def __init__(self):
+            super().__init__(path=str(path), reflection_path=str(refl))
+    monkeypatch.setattr(metabo_cycle, "GoalManager", DummyGM)
+    if goal:
+        DummyGM().set_goal(goal)
+
+
+def test_goal_switch(monkeypatch, tmp_path):
+    setup(monkeypatch, tmp_path, goal="Alt")
+    monkeypatch.setattr(metabo_cycle, "propose_goal", lambda ui: "Neu")
+    monkeypatch.setattr(metabo_cycle, "check_goal_shift", lambda a, b: True)
+    res = metabo_cycle.run_metabo_cycle("User input")
+    assert res["goal"] == "Neu"
+

--- a/tests/test_recall_context.py
+++ b/tests/test_recall_context.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import types
 from memory import recall_context
 
 
@@ -7,11 +8,11 @@ def test_recall_context_global(monkeypatch):
     G.add_edge("A", "B", relation="ab")
     G.add_edge("B", "C", relation="bc")
 
-    class DummyIG:
-        def __init__(self, path="x"):
-            self.graph = G
+    class DummyMem:
+        def __init__(self):
+            self.graph = types.SimpleNamespace(graph=G)
 
-    monkeypatch.setattr(recall_context, "IntentionGraph", DummyIG)
+    monkeypatch.setattr(recall_context, "get_memory_manager", lambda: DummyMem())
     res = recall_context.recall_context(limit=2)
     assert {
         (d["subject"], d["predicate"], d["object"]) for d in res
@@ -26,11 +27,11 @@ def test_recall_context_goal(monkeypatch):
     G.add_edge("goal", "X", relation="r1")
     G.add_edge("Y", "goal", relation="r2")
 
-    class DummyIG:
-        def __init__(self, path="x"):
-            self.graph = G
+    class DummyMem:
+        def __init__(self):
+            self.graph = types.SimpleNamespace(graph=G)
 
-    monkeypatch.setattr(recall_context, "IntentionGraph", DummyIG)
+    monkeypatch.setattr(recall_context, "get_memory_manager", lambda: DummyMem())
     monkeypatch.setattr(recall_context, "get_active_goal", lambda: "goal")
     res = recall_context.recall_context(scope="goal")
     assert {tuple(d.values())[:3] for d in res} == {

--- a/tests/test_reflection_engine.py
+++ b/tests/test_reflection_engine.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from reflection import reflection_engine
+
+
+def setup_common(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self.create)
+            )
+        def create(self, *a, **k):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="resp"))]
+            )
+    monkeypatch.setattr(reflection_engine, "get_client", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(reflection_engine, "run_llm_task", lambda *a, **k: "note")
+    mem = types.SimpleNamespace(
+        graph=types.SimpleNamespace(
+            add_goal_transition=lambda a,b: setattr(mem, "edge", (a,b)),
+            goal_graph=types.SimpleNamespace(add_node=lambda n: None),
+            _save_goal_graph=lambda: None,
+        )
+    )
+    monkeypatch.setattr(reflection_engine, "get_memory_manager", lambda: mem)
+    calls = {}
+    monkeypatch.setattr(reflection_engine.goal_manager, "set_goal", lambda g: calls.setdefault("goal", g))
+    return mem, calls
+
+
+def test_goal_switch(monkeypatch):
+    mem, calls = setup_common(monkeypatch)
+    monkeypatch.setattr(reflection_engine, "detect_goal_shift", lambda *a, **k: (True, "Musik"))
+    res = reflection_engine.generate_reflection("Bitte beschäftige dich mit Musik", "Sport", "", [])
+    assert calls["goal"] == "Musik"
+    assert mem.edge == ("Sport", "Musik")
+    assert res["explanation"] == "note"
+
+
+def test_no_goal_switch(monkeypatch):
+    mem, calls = setup_common(monkeypatch)
+    monkeypatch.setattr(reflection_engine, "detect_goal_shift", lambda *a, **k: (False, None))
+    res = reflection_engine.generate_reflection("Hallo", "Sport", "", [])
+    assert "goal" not in calls
+    assert not hasattr(mem, "edge")
+    assert res["explanation"] == ""
+

--- a/tests/test_subgoal_planner.py
+++ b/tests/test_subgoal_planner.py
@@ -4,45 +4,67 @@ from goals import subgoal_planner
 
 
 def test_missing_openai(monkeypatch):
-    monkeypatch.setattr(subgoal_planner, "openai", None)
-    with pytest.raises(ImportError):
+    monkeypatch.setattr(subgoal_planner, "get_client", lambda *a, **k: None)
+    with pytest.raises(EnvironmentError):
         subgoal_planner.decompose_goal("Goal")
 
 
 def test_missing_api_key(monkeypatch):
-    dummy = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: None))
-    monkeypatch.setattr(subgoal_planner, "openai", dummy)
+    monkeypatch.setattr(subgoal_planner, "get_client", lambda *a, **k: None)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(EnvironmentError):
         subgoal_planner.decompose_goal("Goal")
 
 
 def test_json_reply(monkeypatch):
-    dummy = types.SimpleNamespace()
-    def create(model, temperature, messages):
-        return {"choices": [{"message": {"content": "[\"a\", \"b\"]"}}]}
-    dummy.ChatCompletion = types.SimpleNamespace(create=create)
-    monkeypatch.setattr(subgoal_planner, "openai", dummy)
+    class Dummy:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+
+        def create(self, *a, **k):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="[\"a\", \"b\"]"))]
+            )
+
+    monkeypatch.setattr(subgoal_planner, "get_client", lambda *a, **k: Dummy())
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     res = subgoal_planner.decompose_goal("Goal")
     assert res == ["a", "b"]
 
 
 def test_line_reply(monkeypatch):
-    dummy = types.SimpleNamespace()
-    def create(model, temperature, messages):
-        text = "- eins\n- zwei\n- drei"
-        return {"choices": [{"message": {"content": text}}]}
-    dummy.ChatCompletion = types.SimpleNamespace(create=create)
-    monkeypatch.setattr(subgoal_planner, "openai", dummy)
+    class Dummy:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+
+        def create(self, *a, **k):
+            text = "- eins\n- zwei\n- drei"
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=text))]
+            )
+
+    monkeypatch.setattr(subgoal_planner, "get_client", lambda *a, **k: Dummy())
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     res = subgoal_planner.decompose_goal("Goal")
     assert res == ["eins", "zwei", "drei"]
 
 
 def test_fallback(monkeypatch):
-    dummy = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=lambda **k: {"choices": [{"message": {"content": ""}}]}))
-    monkeypatch.setattr(subgoal_planner, "openai", dummy)
+    dummy = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=lambda **k: types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=""))]))
+        )
+    )
+    monkeypatch.setattr(subgoal_planner, "get_client", lambda *a, **k: dummy)
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     res = subgoal_planner.decompose_goal("Goal")
     assert res == ["Goal"]
+
+
+def test_config_defaults():
+    import inspect
+    from cfg import config
+
+    sig = inspect.signature(subgoal_planner.decompose_goal)
+    assert sig.parameters['model'].default == config.MODELS['subgoal']
+

--- a/tests/test_takt_engine.py
+++ b/tests/test_takt_engine.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control import takt_engine
+
+
+class DummyMem:
+    def __init__(self):
+        self.val = 0.0
+        self.graph = types.SimpleNamespace(add_goal_transition=lambda a,b: None)
+
+    def calculate_entropy(self):
+        return 0.4
+
+    def load_last_entropy(self):
+        return 0.2
+
+    def store_last_entropy(self, value):
+        self.val = value
+
+    def map_entropy_to_emotion(self, delta):
+        return {"delta": delta, "emotion": "neutral", "intensity": "low"}
+
+    def store_reflection(self, reflection):
+        self.reflection = reflection
+
+    def load_reflection(self):
+        return ""
+
+
+def setup(monkeypatch, change_goal=False):
+    mem = DummyMem()
+    monkeypatch.setattr(takt_engine, "get_memory_manager", lambda: mem)
+    monkeypatch.setattr(takt_engine.goal_engine, "get_current_goal", lambda: "A")
+    if change_goal:
+        monkeypatch.setattr(takt_engine.goal_engine, "update_goal", lambda **k: "B")
+    else:
+        monkeypatch.setattr(takt_engine.goal_engine, "update_goal", lambda **k: "A")
+    monkeypatch.setattr(takt_engine, "run_llm_task", lambda *a, **k: "ref")
+    return mem
+
+
+def test_metabotakt_no_change(monkeypatch):
+    mem = setup(monkeypatch, change_goal=False)
+    res = takt_engine.run_metabotakt(api_key=None)
+    assert res["goal"] == "A"
+    assert res["goal_update"] == ""
+    assert mem.val == 0.4
+
+
+def test_metabotakt_goal_change(monkeypatch):
+    mem = setup(monkeypatch, change_goal=True)
+    res = takt_engine.run_metabotakt(api_key=None)
+    assert res["goal"] == "B"
+    assert "Neues Ziel" in res["goal_update"]

--- a/tests/test_triplet_extractor.py
+++ b/tests/test_triplet_extractor.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import logging
-import types
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from parsing import triplet_extractor

--- a/zip_sources.sh
+++ b/zip_sources.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Compress all Python source files of MetaboMind into a ZIP archive
+# Usage: ./zip_sources.sh [output.zip]
+
+set -euo pipefail
+
+out_file="${1:-metabomind_sources.zip}"
+
+# Find all .py files excluding __pycache__ directories and feed them to zip
+find . -type d -name '__pycache__' -prune -o -name '*.py' -print | zip -@ "$out_file"
+
+echo "Created $out_file"


### PR DESCRIPTION
## Summary
- allow explicit and LLM-proposed goal changes
- create a short reflection when switching goals
- ensure cycle results contain `goal_reflection`
- test that `update_goal` consults the LLM when explicit command is absent
- detect new user goals when running `run_metabo_cycle`
- detect goal shifts in `generate_reflection`
- unit test reflection goal update logic
- improve goal shift detection with conversation context
- centralize prompts and model settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea3c3cb90832eb766bfd820c97b64