### PR TITLE
Add docs and UML diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# MetaboMind
+
+MetaboMind is a simple goal-oriented reasoning demo. The main entry point is
+`main.py` which launches a small GUI and handles the cycle logic.
+
+Runtime data such as logs or graphs are stored in the `data/` directory.
+
+## Diagrams
+
+### Class overview
+
+![Class Diagram](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuKhEIImkLl1DpCo3CLDB4fFodIkJSrAX8kxvYJc-YNc9wQb5S3Mv-KMLg6AUUIMfUIMP-NdkHOa56L31eDIqdDHaaAXhNdfc7ip4aCJi4gW0o6O5NLqx57kHs60vP1UWow6w1LqMmm4eoi5Aq1oES1iMuz4aaTtba9gN0WfG0000)
+
+### Cycle sequence
+
+![Sequence Diagram](https://www.plantuml.com/plantuml/png/XP4nYyCm38Lt_mhHAJUqFo33KJYEJbaAdOtEKNC6HpQoKYx__k8CRTC4kedlFJqzx6DM51twOD1f5BXa4fCcv9rFo0gx7ZqVqhW3pD1Cyq9jIF4dVeqkq8AV8eO66RkNj8RwAEEMSgPh8AS-yZTtdicK9h3_d6_Mu3aD2af_QWgOXSVj6cHWsy_0kaAgOlqmJvwoybIhXexKTXEeLhP5oneoOyg_KTV6rz8bb4bGoSfTUfkFRMjLV0ga-NqPl96Tq5Ro_RM4yX3K78dRyhN_)

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -1,0 +1,16 @@
+@startuml
+class Main
+class MetaboCycle
+class GoalManager
+class MemoryManager
+class IntentionGraph
+class ReflectionEngine
+class TaktEngine
+Main --> MetaboCycle
+MetaboCycle --> GoalManager
+MetaboCycle --> MemoryManager
+MetaboCycle --> ReflectionEngine
+MemoryManager --> IntentionGraph
+TaktEngine --> MemoryManager
+TaktEngine --> GoalManager
+@enduml

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -1,0 +1,16 @@
+@startuml
+actor User
+participant "main.py" as Main
+participant MetaboCycle
+participant GoalManager
+participant MemoryManager
+participant ReflectionEngine
+User -> Main: input text
+Main -> MetaboCycle: run_metabo_cycle(text)
+MetaboCycle -> GoalManager: get_goal()
+MetaboCycle -> MemoryManager: snapshot()
+MetaboCycle -> ReflectionEngine: generate_reflection()
+MetaboCycle -> MemoryManager: add_triplets()
+MetaboCycle -> MemoryManager: save_emotion()
+MetaboCycle --> Main: result
+@enduml


### PR DESCRIPTION
## Summary
- add initial README with PlantUML diagrams
- create doc/diagrams with class and sequence diagrams
- add empty `data/` folder to keep runtime files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715e7be5d8832e8c9eb9ee343def6c