### PR TITLE
Set default entropy file to data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ MetaboMind is a simple goal-oriented reasoning demo. The main entry point is
 `main.py` which launches a small GUI and handles the cycle logic.
 
 Runtime data such as logs or graphs are stored in the `data/` directory.
+The `MemoryManager` also keeps its entropy snapshot under
+`data/last_entropy.txt` by default.
 
 All prompts used for LLM interactions are defined centrally in `cfg/config.py`.
 The Metabo rules are stored in `METABO_PROMPT` and automatically prefixed to

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -18,7 +18,7 @@ class MemoryManager:
         graph_path: str = "data/graph.gml",
         emotion_log: str = "data/emotions.jsonl",
         reflection_path: str = "memory/last_reflection.txt",
-        entropy_path: str = "memory/last_entropy.txt",
+        entropy_path: str = "data/last_entropy.txt",
     ) -> None:
         self.graph = IntentionGraph(graph_path)
         self.emotion_log = Path(emotion_log)


### PR DESCRIPTION
## Summary
- keep entropy data under `data/last_entropy.txt` by default
- document new file location in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68717c2b82ec832e881c9938d72af9fc