### PR TITLE
Improve Yin mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ All prompts used for LLM interactions are defined centrally in `cfg/config.py`.
 The Metabo rules are stored in `METABO_PROMPT` and automatically prefixed to
 each system prompt.
 
+The controller now decides between Yin and Yang using sentiment analysis,
+vague language detection and subgoal progress in addition to the entropy trend.
+
 ## Diagrams
 
 ### Class overview
 
-![Class Diagram](https://www.plantuml.com/plantuml/png/RP512i8m44NtFKKlq2j8GQIuA8AuwNACOnfC9pAPBdfxQMaqYTaD_tzctcTQBy0oJxPI5holUp0KHXIuk-EYBEvAvy3sGA2Hlvd9yP9gPn8aCOuwXlUuYrTyMbIhUY9jA6oymKiIOJ0q0EaBgn6zC8ZZQcMgc-QG44NpviLikPTIvkuVMXueCiKhjrHM-zUiW92P2NieMxhQ8ZtMNtq0)
+![Class Diagram](https://www.plantuml.com/plantuml/png/TL912i8m4Bpt5JagwWSyI45418iWNZoLRRAsmNGZoGhszxPYjOdrDinCDZl3ffx1yRqsYJJWlSX0Km-HeR3hHXfyCriB9WE24jt7KrlNXDoE68crfQs3M_KcZtWnA3jsGwMcVk89hXmGPqrdeFBWP8MU7R1roGWdbcAcK6g5UMqLJcfafwMV2yO7puM_5xcoXDC_R_DA-nOrBTotAEbIYyLY5MGUu9SsJ1zhOG-n-XC-Deob3aQ-N56nt-v6LeZ4OFS-xDYlAP9gh-49)
 
 ### Cycle sequence
 
-![Sequence Diagram](https://www.plantuml.com/plantuml/png/XP8nQyCm48Lt_OeZKpgqFq1329JIoHGA7JA9gtHr1F99IETI__j87j8uDcGJttjwUdVeM0IpZ4DGQ2Lc-2gKLQh8Mv-G1NO3Udv9qmwmG5VF2xKZmU_uEjb02_uUCNJ8sD-bTJJ4F6qfd_GJo8gF_CQzvsNSoVC9kV_8zan5CjQcgZM5vyFSIOFdD0e8_ObgO1R-ksd88vjX1iOsic_M9tNZQLSstj7Wo7f7PeYEzgiRDuDgw4bCNy7QjfXRGs5CvHnbRRnVGmjbgat8vAlqC1-TCv9z2YJbSHdy9LFHLl9rlvdA64GTYLtxB1S0)
+![Sequence Diagram](https://www.plantuml.com/plantuml/png/XPAnQiGm44HxVSLobLCa7w0Y78IGoWG2AQuI6sdZ4yWh8Qr3_FUHN5pEPyDruireDBleM0IpJ6DGQ2Lc-2oKLQh8Mv-G1GuZUdvAym6mG5_FAxKdmQ_uCjj0A_uMCVJ8EDoazJJ6FEyf7_GTo8gF_Cg3vtNSoVC9UNZFzan5CjQcgZM5n-UbamRFQH8G-XNLm2ByTzEG9pRZ0enjf6lM1tNbQLTstj7Wo7f7PeoEkXgHlIsRYrVpQXX8p511jx6jnjTG65CvHzaQRxVHGfbg8JBv8jtDH-TCxPi2IRbV1d_8LBINV5bpfZ85KKTYL__C7m00)

--- a/control/metabo_cycle.py
+++ b/control/metabo_cycle.py
@@ -38,7 +38,14 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
     ent_before_cycle = memory.load_last_entropy()
     current_ent = entropy_of_graph(memory.graph.snapshot())
     delta_initial = current_ent - ent_before_cycle
-    mode = decide_mode({"entropy_delta": delta_initial}, user_input)
+
+    try:
+        path = memory.graph.get_goal_path()
+        sub_done = max(len(path) - 1, 0)
+    except Exception:
+        sub_done = 0
+
+    mode = decide_mode({"entropy_delta": delta_initial}, user_input, sub_done)
     logger.info("MetaboMind mode: %s", mode)
 
     goal = goal_mgr.get_goal()

--- a/control/yin_yang_controller.py
+++ b/control/yin_yang_controller.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import Dict, List
+
+from textblob import TextBlob
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,7 @@ class YinYangOrchestrator:
         self._mode = "yang"
         self._override: str | None = None
         self._deltas: List[float] = []
+        self._history: List[str] = []
         self._heartbeat = heartbeat or 0
         self._next_beat = (
             datetime.utcnow() + timedelta(seconds=self._heartbeat)
@@ -34,8 +38,14 @@ class YinYangOrchestrator:
             self._override = self._mode
             logger.info("Mode manually set to %s", self._mode)
 
-    def decide_mode(self, context_metrics: Dict[str, float], user_input: str) -> str:
-        """Return 'yin' or 'yang' according to entropy trend and hints."""
+    def decide_mode(
+        self,
+        context_metrics: Dict[str, float],
+        user_input: str,
+        subgoal_count: int = 0,
+    ) -> str:
+        """Return ``'yin'`` or ``'yang'`` based on multiple indicators."""
+
         if self._override:
             return self._override
 
@@ -47,20 +57,57 @@ class YinYangOrchestrator:
 
         text = user_input.lower()
 
+        # ----------------------------------
+        # indicator collection
+        yin_votes = 0
+
+        # negative or uncertain sentiment
+        try:
+            polarity = TextBlob(text).sentiment.polarity
+        except Exception:  # pragma: no cover - sentiment failed
+            polarity = 0.0
+        if polarity < -0.1:
+            yin_votes += 1
+
+        # vague or reflective phrases
+        vague_patterns = [
+            r"ich wei[ßs]? nicht",
+            r"keine ahnung",
+            r"was vorher",
+            r"\büberfordert\b",
+        ]
+        if any(re.search(p, text) for p in vague_patterns):
+            yin_votes += 1
+
+        # entropy trend
+        if trend > 0.1:
+            yin_votes += 1
+
+        # few completed subgoals
+        if subgoal_count < 2:
+            yin_votes += 1
+
+        # cumulative yin tendency
+        if len(self._history) >= 3 and len(set(self._history[-3:])) == 1:
+            yin_votes += 1
+
+        # ----------------------------------
         if "/takt" in text or "denk" in text or "reflekt" in text:
-            self._mode = "yin"
+            mode = "yin"
         elif "aktion" in text or "mach" in text or "tu was" in text:
-            self._mode = "yang"
+            mode = "yang"
         else:
-            if trend > 0.1:
-                self._mode = "yin"
-            elif trend < -0.1:
-                self._mode = "yang"
+            mode = "yin" if yin_votes > 2 else "yang"
 
         if self._heartbeat and self._next_beat and datetime.utcnow() >= self._next_beat:
             self._next_beat = datetime.utcnow() + timedelta(seconds=self._heartbeat)
-            self._mode = "yin" if self._mode == "yang" else "yang"
-            logger.info("Heartbeat toggled mode to %s", self._mode)
+            mode = "yin" if mode == "yang" else "yang"
+            logger.info("Heartbeat toggled mode to %s", mode)
+
+        self._mode = mode
+        self._history.append(mode)
+        if len(self._history) > 5:
+            self._history.pop(0)
 
         return self._mode
 
@@ -68,8 +115,10 @@ class YinYangOrchestrator:
 # Shared orchestrator ---------------------------------------------------
 _ORCHESTRATOR = YinYangOrchestrator()
 
-def decide_mode(context_metrics: Dict[str, float], user_input: str) -> str:
-    return _ORCHESTRATOR.decide_mode(context_metrics, user_input)
+def decide_mode(
+    context_metrics: Dict[str, float], user_input: str, subgoal_count: int = 0
+) -> str:
+    return _ORCHESTRATOR.decide_mode(context_metrics, user_input, subgoal_count)
 
 def current_mode() -> str:
     return _ORCHESTRATOR.mode

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -7,6 +7,8 @@ class IntentionGraph
 class ReflectionEngine
 class TaktEngine
 class YinYangOrchestrator
+YinYangOrchestrator : +decide_mode(metrics, text, sub_done)
+YinYangOrchestrator : _history : List
 Main --> MetaboCycle
 MetaboCycle --> GoalManager
 MetaboCycle --> MemoryManager

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -8,7 +8,7 @@ participant ReflectionEngine
 participant YinYangOrchestrator
 User -> Main: input text
 Main -> MetaboCycle: run_metabo_cycle(text)
-MetaboCycle -> YinYangOrchestrator: decide_mode()
+MetaboCycle -> YinYangOrchestrator: decide_mode(metrics)
 MetaboCycle -> GoalManager: get_goal()
 MetaboCycle -> MemoryManager: snapshot()
 MetaboCycle -> ReflectionEngine: generate_reflection()

--- a/tests/test_metabo_cycle.py
+++ b/tests/test_metabo_cycle.py
@@ -20,6 +20,8 @@ def setup(monkeypatch, tmp_path, goal=""):
             self.goal_graph.add_edge(a, b)
         def _save_goal_graph(self):
             pass
+        def get_goal_path(self):
+            return list(self.goal_graph.nodes())
 
     class DummyMem:
         def __init__(self):

--- a/tests/test_yin_yang_controller.py
+++ b/tests/test_yin_yang_controller.py
@@ -1,0 +1,12 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control import yin_yang_controller as yyc
+
+
+def test_yin_decision_with_uncertainty():
+    orch = yyc.YinYangOrchestrator()
+    orch._history = ["yin", "yin", "yin"]
+    mode = orch.decide_mode({"entropy_delta": 0.2}, "Ich weiß nicht, was vorher war", 0)
+    assert mode == "yin"


### PR DESCRIPTION
## Summary
- enhance `decide_mode` with sentiment and vague language checks
- count completed subgoals and keep a mode history
- use new indicators when running a cycle
- update diagrams and README
- add regression tests for decision logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687274291b08832eba8f9ff34973632f