### PR TITLE
Improve Yin mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,18 @@ All prompts used for LLM interactions are defined centrally in `cfg/config.py`.
 The Metabo rules are stored in `METABO_PROMPT` and automatically prefixed to
 each system prompt.
 
+Yin and Yang are primarily selected by an LLM via the function
+`decide_yin_yang_mode(user_input, metrics)`.  The metrics include the current
+entropy delta and a rough emotion estimate.  The orchestrator keeps a simple
+heuristic fallback and prints a short debug message whenever the mode changes.
+
 ## Diagrams
 
 ### Class overview
 
-![Class Diagram](https://www.plantuml.com/plantuml/png/RP512i8m44NtFKKlq2j8GQIuA8AuwNACOnfC9pAPBdfxQMaqYTaD_tzctcTQBy0oJxPI5holUp0KHXIuk-EYBEvAvy3sGA2Hlvd9yP9gPn8aCOuwXlUuYrTyMbIhUY9jA6oymKiIOJ0q0EaBgn6zC8ZZQcMgc-QG44NpviLikPTIvkuVMXueCiKhjrHM-zUiW92P2NieMxhQ8ZtMNtq0)
+![Class Diagram](https://www.plantuml.com/plantuml/png/dZLBqsIwEEX3_YosFfUH3kIEeYigPBA3rso0GdtgOpHJFOzf24pVk1d3l3tvJpNDVkGApaldph2EoPZgaZAoUPh1qx0-nY0HtweCEvnVqT23sbclQRLracNwrZ7mAc8Ode_-UmlpmHiEi0TGydIJqPxjXWEQBvGcjXjqR80Mamswr73BSY3CVoe5ErzJXIWmyI0nnH4_WzRlfmVLMvlWyisbOtV2cteprEejFotlBOZDP7JPRGkWw0rTf4TSwhiaaOSjldB_Ax5ZIQmj3YfHjt26QjL9l7kD)
 
 ### Cycle sequence
 
-![Sequence Diagram](https://www.plantuml.com/plantuml/png/XP8nQyCm48Lt_OeZKpgqFq1329JIoHGA7JA9gtHr1F99IETI__j87j8uDcGJttjwUdVeM0IpZ4DGQ2Lc-2gKLQh8Mv-G1NO3Udv9qmwmG5VF2xKZmU_uEjb02_uUCNJ8sD-bTJJ4F6qfd_GJo8gF_CQzvsNSoVC9kV_8zan5CjQcgZM5vyFSIOFdD0e8_ObgO1R-ksd88vjX1iOsic_M9tNZQLSstj7Wo7f7PeYEzgiRDuDgw4bCNy7QjfXRGs5CvHnbRRnVGmjbgat8vAlqC1-TCv9z2YJbSHdy9LFHLl9rlvdA64GTYLtxB1S0)
+![Sequence Diagram](https://www.plantuml.com/plantuml/png/hZJBawMhEIXv_oohp82h_QF7KIFSeloKgR5ykolOjeCOorOl---rOaTZZGlu8t7z8zm6K4JZpjEoNBIzfBbKKlXJG5-QBTYjen5O8wawwFDXC3cgwWN8nU2ghf4eMQzI6G5oA40xz2vOnr4CGfGR39h5XuIOng_I7iObExXJWJuq1hSeXs6devCcJgGhH1FNOBt_3XrIE-vxLGjTlK5Ft-oq07asnNODJeMt6TFa6ioie1O2aiX5D-A4OZ2yZ-nujryaVA-ORLsq3McWg-uhMKZyiiu82zk2KFNtQjpfrId8tFbXm6ZAUh6XwW_SVVojXx4oU5mCqB2xbb_tFw==)
+

--- a/cfg/config.py
+++ b/cfg/config.py
@@ -63,6 +63,11 @@ PROMPTS = {
         "Pr\u00fcfe anhand der Nutzereingabe, ob ein neues Thema verfolgt werden soll. "
         "Nutze die Funktion 'propose_goal', wenn ein klares neues Ziel erkennbar ist."
     ),
+    'mode_decider_system': (
+        METABO_PROMPT + "\n" +
+        "Beurteile anhand der Nutzereingabe und der Metriken, ob Yin oder Yang angemessen ist. "
+        "Begr\u00fcnde deine Entscheidung knapp \u00fcber die Funktion 'decide_yin_yang_mode'."
+    ),
     'goal_shift_reflection': (
         METABO_PROMPT + "\nReflektiere kurz den Zielwechsel von '{old}' zu '{new}'."
     ),

--- a/control/metabo_cycle.py
+++ b/control/metabo_cycle.py
@@ -16,6 +16,7 @@ from reasoning.entropy_analyzer import entropy_of_graph
 from goals.subgoal_planner import decompose_goal
 from goals.subgoal_executor import execute_first_subgoal
 from control.yin_yang_controller import decide_mode, current_mode
+from control.mode_decider import decide_yin_yang_mode
 from difflib import SequenceMatcher
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,20 @@ def run_metabo_cycle(user_input: str) -> Dict[str, object]:
     ent_before_cycle = memory.load_last_entropy()
     current_ent = entropy_of_graph(memory.graph.snapshot())
     delta_initial = current_ent - ent_before_cycle
-    mode = decide_mode({"entropy_delta": delta_initial}, user_input)
+    initial_emotion = interpret_emotion(ent_before_cycle, current_ent)
+
+    try:
+        path = memory.graph.get_goal_path()
+        sub_done = max(len(path) - 1, 0)
+    except Exception:
+        sub_done = 0
+
+    metrics = {"entropy_delta": delta_initial, "emotion": initial_emotion["emotion"]}
+    mode = decide_mode(metrics, user_input, sub_done)
+    llm_result = decide_yin_yang_mode(user_input, metrics)
+    if llm_result and llm_result.get("mode") in {"yin", "yang"}:
+        mode = llm_result["mode"]
+        logger.info("LLM decided mode: %s (%s)", mode, llm_result.get("rationale", ""))
     logger.info("MetaboMind mode: %s", mode)
 
     goal = goal_mgr.get_goal()

--- a/control/mode_decider.py
+++ b/control/mode_decider.py
@@ -1,0 +1,100 @@
+"""LLM-driven selection of Yin or Yang mode."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Dict, Optional
+
+from utils.llm_client import get_client
+from cfg.config import PROMPTS, MODELS, TEMPERATURES
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = PROMPTS['mode_decider_system']
+
+
+def decide_yin_yang_mode(
+    user_input: str,
+    metrics: Dict[str, float],
+    api_key: str | None = None,
+) -> Optional[Dict[str, str]]:
+    """Return an LLM decision for Yin or Yang.
+
+    Parameters
+    ----------
+    user_input : str
+        Last text from the user.
+    metrics : Dict[str, float]
+        Current metrics like ``emotion`` and ``entropy_delta``.
+    api_key : str | None, optional
+        API key if not provided via ``OPENAI_API_KEY``.
+
+    Returns
+    -------
+    Optional[Dict[str, str]]
+        Dictionary with ``mode`` and optional ``rationale`` or ``None`` if the
+        client is unavailable.
+    """
+    client = get_client(api_key or os.getenv("OPENAI_API_KEY"))
+    if client is None:
+        return None
+
+    content = f"Eingabe: {user_input}\nMetriken: {json.dumps(metrics)}"
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": content},
+    ]
+    functions = [
+        {
+            "name": "decide_yin_yang_mode",
+            "description": "Wähle den Modus yin oder yang",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["yin", "yang"]},
+                    "rationale": {"type": "string"},
+                },
+                "required": ["mode"],
+            },
+        }
+    ]
+
+    try:
+        if hasattr(client, "chat"):
+            resp = client.chat.completions.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call={"name": "decide_yin_yang_mode"},
+            )
+            choice = resp.choices[0]
+            if choice.finish_reason == "function_call":
+                fc = choice.message.function_call
+                if fc and fc.name == "decide_yin_yang_mode":
+                    data = json.loads(fc.arguments)
+                    return {
+                        "mode": data.get("mode", "yin"),
+                        "rationale": data.get("rationale", ""),
+                    }
+        else:
+            resp = client.ChatCompletion.create(
+                model=MODELS['chat'],
+                temperature=TEMPERATURES['chat'],
+                messages=messages,
+                functions=functions,
+                function_call={"name": "decide_yin_yang_mode"},
+            )
+            choice = resp["choices"][0]
+            if choice.get("finish_reason") == "function_call":
+                fc = choice["message"]["function_call"]
+                if fc["name"] == "decide_yin_yang_mode":
+                    data = json.loads(fc["arguments"])
+                    return {
+                        "mode": data.get("mode", "yin"),
+                        "rationale": data.get("rationale", ""),
+                    }
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("mode_decider failed: %s", exc)
+    return None

--- a/control/yin_yang_controller.py
+++ b/control/yin_yang_controller.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List
 
+from textblob import TextBlob
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,6 +16,7 @@ class YinYangOrchestrator:
         self._mode = "yang"
         self._override: str | None = None
         self._deltas: List[float] = []
+        self._history: List[str] = []
         self._heartbeat = heartbeat or 0
         self._next_beat = (
             datetime.utcnow() + timedelta(seconds=self._heartbeat)
@@ -34,8 +37,14 @@ class YinYangOrchestrator:
             self._override = self._mode
             logger.info("Mode manually set to %s", self._mode)
 
-    def decide_mode(self, context_metrics: Dict[str, float], user_input: str) -> str:
-        """Return 'yin' or 'yang' according to entropy trend and hints."""
+    def decide_mode(
+        self,
+        context_metrics: Dict[str, float],
+        user_input: str,
+        subgoal_count: int = 0,
+    ) -> str:
+        """Return ``'yin'`` or ``'yang'`` based on multiple indicators."""
+
         if self._override:
             return self._override
 
@@ -44,23 +53,65 @@ class YinYangOrchestrator:
         if len(self._deltas) > 5:
             self._deltas.pop(0)
         trend = sum(self._deltas) / len(self._deltas)
+        emotion = context_metrics.get("emotion", "")
 
         text = user_input.lower()
 
+        # ----------------------------------
+        # indicator collection
+        yin_votes = 0
+
+        # negative or uncertain sentiment
+        try:
+            polarity = TextBlob(text).sentiment.polarity
+        except Exception:  # pragma: no cover - sentiment failed
+            polarity = 0.0
+        if polarity < -0.1:
+            yin_votes += 1
+
+        # explicit emotion metric
+        if isinstance(emotion, str) and emotion.lower() in {"negative", "unsicher"}:
+            yin_votes += 1
+
+        # sentiment already captures vague expressions; explicit regex no longer used
+
+        # entropy trend
+        if trend > 0.1:
+            yin_votes += 1
+
+        # negative or very small delta
+        if delta < 0 or abs(delta) < 0.01:
+            yin_votes += 1
+
+        # few completed subgoals
+        if subgoal_count < 2:
+            yin_votes += 1
+
+        # cumulative yin tendency
+        if len(self._history) >= 3 and len(set(self._history[-3:])) == 1:
+            yin_votes += 1
+
+        # ----------------------------------
         if "/takt" in text or "denk" in text or "reflekt" in text:
-            self._mode = "yin"
+            mode = "yin"
         elif "aktion" in text or "mach" in text or "tu was" in text:
-            self._mode = "yang"
+            mode = "yang"
         else:
-            if trend > 0.1:
-                self._mode = "yin"
-            elif trend < -0.1:
-                self._mode = "yang"
+            mode = "yin" if yin_votes > 2 else "yang"
 
         if self._heartbeat and self._next_beat and datetime.utcnow() >= self._next_beat:
             self._next_beat = datetime.utcnow() + timedelta(seconds=self._heartbeat)
-            self._mode = "yin" if self._mode == "yang" else "yang"
-            logger.info("Heartbeat toggled mode to %s", self._mode)
+            mode = "yin" if mode == "yang" else "yang"
+            logger.info("Heartbeat toggled mode to %s", mode)
+
+        print(
+            f"[Modus-Entscheidung] Grund: emotion={emotion}, delta={delta:.2f} → {mode.upper()}"
+        )
+
+        self._mode = mode
+        self._history.append(mode)
+        if len(self._history) > 5:
+            self._history.pop(0)
 
         return self._mode
 
@@ -68,8 +119,10 @@ class YinYangOrchestrator:
 # Shared orchestrator ---------------------------------------------------
 _ORCHESTRATOR = YinYangOrchestrator()
 
-def decide_mode(context_metrics: Dict[str, float], user_input: str) -> str:
-    return _ORCHESTRATOR.decide_mode(context_metrics, user_input)
+def decide_mode(
+    context_metrics: Dict[str, float], user_input: str, subgoal_count: int = 0
+) -> str:
+    return _ORCHESTRATOR.decide_mode(context_metrics, user_input, subgoal_count)
 
 def current_mode() -> str:
     return _ORCHESTRATOR.mode

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -7,11 +7,17 @@ class IntentionGraph
 class ReflectionEngine
 class TaktEngine
 class YinYangOrchestrator
+class ModeDecider
+YinYangOrchestrator : +decide_mode(metrics, text, sub_done)
+YinYangOrchestrator : +debug_print()
+YinYangOrchestrator : _history : List
+ModeDecider : +decide_yin_yang_mode(text, metrics)
 Main --> MetaboCycle
 MetaboCycle --> GoalManager
 MetaboCycle --> MemoryManager
 MetaboCycle --> ReflectionEngine
 MetaboCycle --> YinYangOrchestrator
+MetaboCycle --> ModeDecider
 MemoryManager --> IntentionGraph
 TaktEngine --> MemoryManager
 TaktEngine --> GoalManager

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -6,9 +6,13 @@ participant GoalManager
 participant MemoryManager
 participant ReflectionEngine
 participant YinYangOrchestrator
+participant ModeDecider
 User -> Main: input text
 Main -> MetaboCycle: run_metabo_cycle(text)
-MetaboCycle -> YinYangOrchestrator: decide_mode()
+MetaboCycle -> ModeDecider: decide_yin_yang_mode()
+ModeDecider --> MetaboCycle: mode
+MetaboCycle -> YinYangOrchestrator: decide_mode(metrics)
+YinYangOrchestrator -> YinYangOrchestrator: debug_print()
 MetaboCycle -> GoalManager: get_goal()
 MetaboCycle -> MemoryManager: snapshot()
 MetaboCycle -> ReflectionEngine: generate_reflection()

--- a/tests/test_metabo_cycle.py
+++ b/tests/test_metabo_cycle.py
@@ -1,5 +1,4 @@
 import os
-import os
 import sys
 import types
 import networkx as nx
@@ -20,6 +19,8 @@ def setup(monkeypatch, tmp_path, goal=""):
             self.goal_graph.add_edge(a, b)
         def _save_goal_graph(self):
             pass
+        def get_goal_path(self):
+            return list(self.goal_graph.nodes())
 
     class DummyMem:
         def __init__(self):
@@ -58,4 +59,12 @@ def test_goal_switch(monkeypatch, tmp_path):
     monkeypatch.setattr(metabo_cycle, "check_goal_shift", lambda a, b: True)
     res = metabo_cycle.run_metabo_cycle("User input")
     assert res["goal"] == "Neu"
+
+
+def test_llm_mode_override(monkeypatch, tmp_path):
+    setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(metabo_cycle, "decide_yin_yang_mode", lambda *a, **k: {"mode": "yin", "rationale": "test"})
+    monkeypatch.setattr(metabo_cycle, "decide_mode", lambda *a, **k: "yang")
+    res = metabo_cycle.run_metabo_cycle("Hallo")
+    assert res["mode"] == "yin"
 

--- a/tests/test_mode_decider.py
+++ b/tests/test_mode_decider.py
@@ -1,0 +1,29 @@
+import json
+import types
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control import mode_decider
+
+
+def test_no_client(monkeypatch):
+    monkeypatch.setattr(mode_decider, "get_client", lambda *a, **k: None)
+    assert mode_decider.decide_yin_yang_mode("hi", {"entropy_delta": 0}) is None
+
+
+def test_basic_call(monkeypatch):
+    class Dummy:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+        def create(self, *a, **k):
+            return types.SimpleNamespace(choices=[types.SimpleNamespace(
+                finish_reason="function_call",
+                message=types.SimpleNamespace(function_call=types.SimpleNamespace(
+                    name="decide_yin_yang_mode",
+                    arguments=json.dumps({"mode": "yang", "rationale": "ok"})
+                ))
+            )])
+    monkeypatch.setattr(mode_decider, "get_client", lambda *a, **k: Dummy())
+    res = mode_decider.decide_yin_yang_mode("hi", {"entropy_delta": 0})
+    assert res["mode"] == "yang"

--- a/tests/test_yin_yang_controller.py
+++ b/tests/test_yin_yang_controller.py
@@ -1,0 +1,29 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from control import yin_yang_controller as yyc
+
+
+def test_yin_decision_with_uncertainty():
+    orch = yyc.YinYangOrchestrator()
+    orch._history = ["yin", "yin", "yin"]
+    mode = orch.decide_mode({"entropy_delta": -0.05}, "Ich weiss nicht weiter", 0)
+    assert mode == "yin"
+
+
+def test_yin_due_to_negative_emotion():
+    orch = yyc.YinYangOrchestrator()
+    mode = orch.decide_mode(
+        {"entropy_delta": 0.001, "emotion": "negative"}, "Ich bin durcheinander", 0
+    )
+    assert mode == "yin"
+
+
+def test_yin_due_to_small_delta():
+    orch = yyc.YinYangOrchestrator()
+    mode = orch.decide_mode(
+        {"entropy_delta": 0.0, "emotion": "unsicher"}, "Ich bin durcheinander", 1
+    )
+    assert mode == "yin"
+


### PR DESCRIPTION
## Summary
- refine README with new LLM-based mode decision logic
- add a mode_decider component that uses OpenAI function calling
- integrate LLM override in `run_metabo_cycle`
- trim heuristic vague-language detection
- extend tests for new component and override behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687274291b08832eba8f9ff34973632f