### PR TITLE
Switch to logger for mode decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ automatically whenever new triplets are recorded.
 ### Cycle sequence
 
 ![Sequence Diagram](https://www.plantuml.com/plantuml/png/XPF1QiCm38RlVWf3BksXBv33A6oZx306WmvwCggZ9OP4DhAoBcy_EuSsISDw2xz-V_vbAViemD9thG8hdlKn8gkG96TT01BzZW9dVpY-hQZFWsrnfXyyjEz0KDzHEi_3MkKJlrkquZozKkreZZivEW7L7smRZCAG4iwnli8NjAvQG0yCeVboU4bwxaZldcwDbDfHw4KB_egwgZVBs5MfkIVJZOAnMTba_rONXJICK1M5cjZ7qxSmfQx63pCuCaFgm7IfkDcgYKVlbZTcpnAwyW9N-CXC4TdPk5Khpdy0vxusWHr93ZM_SZB3KjSefax2lMqsqb97WX0Rly9RJZX32LCID7mjFUH3LPdKQMXHukCmy8CcIMla-IemnhvThC5aUz9JCLpK7gdA_yWV)
-Updated after deduplicating IntentionGraph functions.
+Updated after logging mode decision via logger.info.
 

--- a/control/yin_yang_controller.py
+++ b/control/yin_yang_controller.py
@@ -103,8 +103,11 @@ class YinYangOrchestrator:
             mode = "yin" if mode == "yang" else "yang"
             logger.info("Heartbeat toggled mode to %s", mode)
 
-        print(
-            f"[Modus-Entscheidung] Grund: emotion={emotion}, delta={delta:.2f} → {mode.upper()}"
+        logger.info(
+            "[Modus-Entscheidung] Grund: emotion=%s, delta=%.2f → %s",
+            emotion,
+            delta,
+            mode.upper(),
         )
 
         self._mode = mode

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -1,5 +1,5 @@
 @startuml
-'/' Updated after deduplicating IntentionGraph functions
+'/' Updated after logging mode decision via logger.info
 class Main
 class MetaboCycle
 class GoalManager

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -1,5 +1,5 @@
 @startuml
-'/' Updated after deduplicating IntentionGraph functions
+'/' Updated after logging mode decision via logger.info
 actor User
 participant MetaboGUI
 participant MetaboCycle


### PR DESCRIPTION
## Summary
- log mode decision using `logger.info` instead of `print`
- update PlantUML diagrams
- refresh README documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a920d908832e9d7faa9125010571