### PR TITLE
Add LLM integration test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Runtime data such as logs or graphs are stored in the `data/` directory.
 ### Cycle sequence
 
 ![Sequence Diagram](https://www.plantuml.com/plantuml/png/XP4nYyCm38Lt_mhHAJUqFo33KJYEJbaAdOtEKNC6HpQoKYx__k8CRTC4kedlFJqzx6DM51twOD1f5BXa4fCcv9rFo0gx7ZqVqhW3pD1Cyq9jIF4dVeqkq8AV8eO66RkNj8RwAEEMSgPh8AS-yZTtdicK9h3_d6_Mu3aD2af_QWgOXSVj6cHWsy_0kaAgOlqmJvwoybIhXexKTXEeLhP5oneoOyg_KTV6rz8bb4bGoSfTUfkFRMjLV0ga-NqPl96Tq5Ro_RM4yX3K78dRyhN_)
+
+### LLM test sequence
+
+![LLM Test Sequence](https://www.plantuml.com/plantuml/png/PP2z2iCW481tdy8n6V826KgWGwSkfPt5cgC8vXGz2Ntx-bEeiPj-Vdntk0IIdk9cc5HaFRz38F3C9QYLTXAfe5j4xF0LI3xj-QqC7FZ5IlDmgyoPMkFJgOdCt4SKbEvX6DcFPwjfLcqhGAXC1eqkqiWQYKzz6a8qr5MRZMOUoq6y4alZcwU_5iBEitQeVPqworbFR05Sy_zz0000)

--- a/doc/diagrams/llm_test_sequence.puml
+++ b/doc/diagrams/llm_test_sequence.puml
@@ -1,0 +1,12 @@
+@startuml
+actor Tester
+participant TestRunner
+participant MetaboCycle
+participant GoalUpdater
+Tester -> TestRunner: run_tests()
+TestRunner -> MetaboCycle: run_metabo_cycle(input)
+MetaboCycle --> TestRunner: result
+TestRunner -> GoalUpdater: update_goal()
+GoalUpdater --> TestRunner: new goal
+TestRunner --> Tester: report
+@enduml

--- a/tests/llm/test_dialogs.yaml
+++ b/tests/llm/test_dialogs.yaml
@@ -1,0 +1,14 @@
+- input: "Ich verstehe gar nichts mehr"
+  expected:
+    mode: "YIN"
+    emotion: "negative"
+    delta_range: [-1.0, -0.01]
+    answer_contains: "verwirrt"
+    goal_hint: null
+- input: "Ich möchte mehr über Musik wissen"
+  expected:
+    mode: "YANG"
+    emotion: "positive"
+    delta_range: [0.05, 1.0]
+    answer_contains: "Musik"
+    goal_hint: "Musik"

--- a/tests/llm/test_runner.py
+++ b/tests/llm/test_runner.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from control.metabo_cycle import run_metabo_cycle
+from goals.goal_engine import update_goal
+from goals.goal_manager import GoalManager
+
+LOG_PATH = os.path.join('data', 'llm_test_log.md')
+
+
+def load_cases(path: str):
+    with open(path, 'r', encoding='utf-8') as fh:
+        return yaml.safe_load(fh) or []
+
+
+def determine_mode(delta: float) -> str:
+    return 'YANG' if delta >= 0 else 'YIN'
+
+
+def check_case(idx: int, case: dict, goal_mgr: GoalManager, logger):
+    user_input = case['input']
+    exp = case.get('expected', {})
+    result = run_metabo_cycle(user_input)
+    new_goal = update_goal(
+        user_input=user_input,
+        last_reflection=result.get('reflection', ''),
+        triplets=result.get('triplets', []),
+    )
+    goal_mgr.set_goal(new_goal)
+
+    answer = result.get('reflection', '')
+    emotion = result.get('emotion', '')
+    delta = result.get('delta', 0.0)
+    mode = determine_mode(delta)
+
+    passed = True
+    reasons = []
+
+    if exp.get('emotion') is not None and emotion != exp['emotion']:
+        passed = False
+        reasons.append(f"expected emotion {exp['emotion']}, got {emotion}")
+    rng = exp.get('delta_range')
+    if isinstance(rng, list) and len(rng) == 2:
+        if not (rng[0] <= delta <= rng[1]):
+            passed = False
+            reasons.append(f"Δ{delta:+.2f} not in range {rng}")
+    if exp.get('mode') and mode != exp['mode']:
+        passed = False
+        reasons.append(f"expected {exp['mode']}, got {mode}")
+    if exp.get('answer_contains') and exp['answer_contains'] not in answer:
+        passed = False
+        reasons.append(
+            f"answer does not contain '{exp['answer_contains']}'")
+    if exp.get('goal_hint'):
+        if exp['goal_hint'] not in new_goal:
+            passed = False
+            reasons.append(
+                f"goal not adjusted to '{exp['goal_hint']}'")
+
+    if passed:
+        msg = f"✅ Test {idx} passed"
+    else:
+        msg = f"❌ Test {idx} failed: {'; '.join(reasons)}"
+    print(msg)
+    if logger:
+        logger.write(msg + '\n')
+    return passed
+
+
+def run_tests(path: str = os.path.join('tests', 'llm', 'test_dialogs.yaml')) -> None:
+    cases = load_cases(path)
+    goal_mgr = GoalManager()
+    logger = None
+    if LOG_PATH:
+        os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+        logger = open(LOG_PATH, 'a', encoding='utf-8')
+    try:
+        for idx, case in enumerate(cases, 1):
+            check_case(idx, case, goal_mgr, logger)
+    finally:
+        if logger:
+            logger.close()
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
## Summary
- add `tests/llm/test_runner.py` and YAML catalog for LLM based tests
- log test results in `data/llm_test_log.md`
- include new PlantUML diagram and embed it in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b1c13b80832ebcebedb6ac16ca3b