### PR TITLE
Extend Yin-Yang uncertainty detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Yin and Yang are primarily selected by an LLM via the function
 `decide_yin_yang_mode(user_input, metrics)`.  The metrics include the current
 entropy delta and a rough emotion estimate.  The orchestrator keeps a simple
 heuristic fallback.  Intermediate metrics and debug output are displayed in the
-GUI tabs while the chat only shows the user text and the final LLM answer.
+GUI tabs while the chat only shows the user text and the final LLM answer.  In
+addition, the orchestrator increases Yin votes whenever typical German phrases
+expressing confusion (e.g. "ich verstehe nicht", "gar nichts mehr", "bin
+verwirrt") are detected.
 The "Wissensgraph" tab visualises the knowledge graph with zoomable nodes and
 edges, including tooltips for quick inspection. The graph can be panned by
 dragging with the left mouse button, zoomed via the mouse wheel and it updates
@@ -37,7 +40,7 @@ automatically whenever new triplets are recorded.
 
 ### Class overview
 
-![Class Diagram](https://www.plantuml.com/plantuml/png/VLD1QiCm4Bpx5JecDFb03oNG5XD8A9Isa9DPorjRr5u5QKthtrTsx5HIxDw6tT7EQ4VQMGR3RLCdiWPhnH4KJH0PSltOoHh7IggXFW91YURAQRJfmjgU68cLfjJ0kHgBh_XPe-ohprGgcYQ-mHS7XPEY4r3vOcI5bWsmlahf0fzGgi8Jxmscx_l9Ng_teV3RCMRcY7jnLmm3iiRDMZN8Hacx4Om_l16spRD24wwNp-PjcPsD8bujaR9AMOSw1myE9PvfJxvJb7NkyCN7HNvqiqxw1CHs-n3ityD3pqyYxeMPnDsR86B2N08t4buMWTpGZHx0NyOpzg9cSAzf4SkENFRngjoQMujMS6KGYeZdgVr7yn-IX-SkjqCg-j_p2m00)
+![Class Diagram](https://www.plantuml.com/plantuml/png/VLHDJyCm3BtlL-J69ZQuSq2J04sJc90GGzefyXAlZMYTaRXivTUJTX-aNRlRav_jz-8-TUeP71TvDhYvln7BhGP6BM33w0HeRIWH3hyBup17Od_7Unwe3BmN2p1qWiYmja-bol1OcLd85a2Ge3ltvDQLpTgSE2mrbcOEjkcn-8wR35LLVQ74q6dZ1tnnex0oj09AtfnAqRC3jcSfg_4PbT6HU6LmjfoVx5LwdmPteIF2ua7SQWUxuQXTbPRahxLvDnDc4baVyWgVsnyCT8VjMhRs6veq3dDaPvGV2yOzZuKlrb9RmYkpwoAHMsU8UmLaQdn0PO2l0VMjaieIXm_hPK4ANGMv75O-HeFeh97Zqf0imwQ3zOFZumF2I9WNaybZ8o4HhhauAsskcPesUn6LTaDNHYuaehGqv6gs5T7_57ROQv6DTvqEqUyefBDzgd3cmgCNd3e4tUgBrAwrzKMzut5J95tz2Vu0)
 
 ### Cycle sequence
 

--- a/control/yin_yang_controller.py
+++ b/control/yin_yang_controller.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 class YinYangOrchestrator:
     """Manage Yin/Yang mode switching based on context metrics."""
 
+    UNCERTAINTY_PATTERNS = [
+        re.compile(r"ich verstehe nicht", re.IGNORECASE),
+        re.compile(r"gar nichts mehr", re.IGNORECASE),
+        re.compile(r"bin verwirrt", re.IGNORECASE),
+    ]
+
     def __init__(self, heartbeat: int | None = None) -> None:
         self._mode = "yang"
         self._override: str | None = None
@@ -27,6 +33,13 @@ class YinYangOrchestrator:
 
     # ------------------------------------------------------------------
     # Mode helpers
+    def _contains_uncertainty(self, text: str) -> bool:
+        """Return True if the text contains predefined uncertainty phrases."""
+        for pattern in self.UNCERTAINTY_PATTERNS:
+            if pattern.search(text):
+                return True
+        return False
+
     @property
     def mode(self) -> str:
         return self._mode
@@ -61,6 +74,9 @@ class YinYangOrchestrator:
         # ----------------------------------
         # indicator collection
         yin_votes = 0
+
+        if self._contains_uncertainty(text):
+            yin_votes += 1
 
         # negative or uncertain sentiment
         try:

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -18,6 +18,7 @@ GraphViewer : +_on_drag_move()
 YinYangOrchestrator : +decide_mode(metrics, text, sub_done)
 YinYangOrchestrator : +debug_print()
 YinYangOrchestrator : _history : List
+YinYangOrchestrator : +_contains_uncertainty(text)
 ModeDecider : +decide_yin_yang_mode(text, metrics)
 Main --> MetaboCycle
 MetaboCycle --> GoalManager

--- a/tests/test_yin_yang_controller.py
+++ b/tests/test_yin_yang_controller.py
@@ -27,3 +27,9 @@ def test_yin_due_to_small_delta():
     )
     assert mode == "yin"
 
+
+def test_uncertainty_phrase_triggers_yin_even_neutral():
+    orch = yyc.YinYangOrchestrator()
+    mode = orch.decide_mode({"entropy_delta": 0.0}, "Ich verstehe gar nichts mehr", 0)
+    assert mode == "yin"
+


### PR DESCRIPTION
## Summary
- detect German uncertainty phrases like "ich verstehe nicht" in `YinYangOrchestrator`
- test that neutral polarity still yields Yin when phrase is used
- document new behaviour in README
- update UML class diagram

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bdef6224832e8c7a4afa67b17b6d