### PR TITLE
Use mode from cycle result in LLM tests

### DIFF
--- a/tests/llm/test_runner.py
+++ b/tests/llm/test_runner.py
@@ -19,10 +19,6 @@ def load_cases(path: str):
         return yaml.safe_load(fh) or []
 
 
-def determine_mode(delta: float) -> str:
-    return 'YANG' if delta >= 0 else 'YIN'
-
-
 def check_case(idx: int, case: dict, goal_mgr: GoalManager, logger):
     user_input = case['input']
     exp = case.get('expected', {})
@@ -37,7 +33,7 @@ def check_case(idx: int, case: dict, goal_mgr: GoalManager, logger):
     answer = result.get('reflection', '')
     emotion = result.get('emotion', '')
     delta = result.get('delta', 0.0)
-    mode = determine_mode(delta)
+    mode = (result.get('mode') or '').upper()
 
     passed = True
     reasons = []


### PR DESCRIPTION
## Summary
- simplify `test_runner` by removing unused mode helper
- pull the Yin/Yang mode directly from `run_metabo_cycle`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c2648d00832eae2a5182ec7feedb