### PR TITLE
Introduce MetaboGraph unified network

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Install the dependencies listed in `requirements.txt`:
 pip install -r requirements.txt
 ```
 
+The test suite also relies on `pyyaml`, included in the requirements.
+
 All tests can then be executed with `pytest`.
 
 All prompts used for LLM interactions are defined centrally in `cfg/config.py`.
@@ -38,6 +40,14 @@ dragging with the left mouse button, zoomed via the mouse wheel and it updates
 automatically whenever new triplets are recorded.
 The module `graph_entropy_scorer` analyses the semantic order of this graph and
 provides a normalized entropy score with textual explanation.
+
+## MetaboGraph
+
+All individual graphs are consolidated into the `MetaboGraph`. Each node carries
+a `typ` attribute like `konzept`, `intention` or `emotion` and optional
+`source` metadata. The graph is persisted as `data/metabograph.gml` and helper
+functions allow extraction of subgraphs by type and calculation of its Shannon
+entropy.
 
 ## Diagrams
 

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -12,12 +12,22 @@ class ModeDecider
 class MetaboGUI
 class GraphViewer
 class GraphEntropyScorer
+class MetaboGraph
 GraphViewer : +draw()
 GraphViewer : +_on_zoom()
 GraphViewer : +_on_drag_start()
 GraphViewer : +_on_drag_move()
 GraphEntropyScorer : +calculate_entropy(graph)
 GraphEntropyScorer : +explain_entropy(graph)
+MetaboGraph : +add_graph(graph)
+MetaboGraph : +add_triplets(triplets)
+MetaboGraph : +calculate_entropy()
+MetaboGraph : +snapshot()
+MetaboGraph : +save()
+MetaboGraph : -_load()
+MetaboGraph : -_merge_node(node, typ, source)
+MetaboGraph : filepath : Path
+MetaboGraph : graph : MultiDiGraph
 YinYangOrchestrator : +decide_mode(metrics, text, sub_done)
 YinYangOrchestrator : +debug_print()
 YinYangOrchestrator : _history : List
@@ -30,6 +40,7 @@ MetaboCycle --> ReflectionEngine
 MetaboCycle --> YinYangOrchestrator
 MetaboCycle --> ModeDecider
 MemoryManager --> IntentionGraph
+MemoryManager --> MetaboGraph
 TaktEngine --> MemoryManager
 TaktEngine --> GoalManager
 Main --> YinYangOrchestrator

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -19,6 +19,8 @@ MetaboCycle -> GraphEntropyScorer: calculate_entropy()
 GraphEntropyScorer --> MetaboCycle: score
 MetaboCycle -> ReflectionEngine: generate_reflection()
 MetaboCycle -> MemoryManager: add_triplets()
+MemoryManager -> MetaboGraph: add_triplets()
+MetaboGraph -> MetaboGraph: save()
 MetaboCycle -> MemoryManager: save_emotion()
 MetaboCycle -> YinYangOrchestrator: decide_mode(metrics)
 MetaboCycle -> ModeDecider: decide_yin_yang_mode(metrics)

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,1 +1,9 @@
 from .memory_manager import MemoryManager, get_memory_manager
+from .metabo_graph import MetaboGraph, extract_subgraph_by_type
+
+__all__ = [
+    "MemoryManager",
+    "get_memory_manager",
+    "MetaboGraph",
+    "extract_subgraph_by_type",
+]

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from memory.intention_graph import IntentionGraph
+from memory.metabo_graph import MetaboGraph
 from reasoning.entropy_analyzer import entropy_of_graph
 from reasoning.graph_entropy_scorer import calculate_entropy as score_graph
 from reasoning.emotion import interpret_emotion
@@ -20,8 +21,10 @@ class MemoryManager:
         emotion_log: str = "data/emotions.jsonl",
         reflection_path: str = "data/last_reflection.txt",
         entropy_path: str = "data/last_entropy.txt",
+        meta_path: str = "data/metabograph.gml",
     ) -> None:
         self.graph = IntentionGraph(graph_path)
+        self.metabo_graph = MetaboGraph(meta_path)
         self.emotion_log = Path(emotion_log)
         self.emotion_log.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)
@@ -37,6 +40,11 @@ class MemoryManager:
         before = entropy_of_graph(self.graph.snapshot())
         if triplets:
             self.graph.add_triplets(triplets)
+            try:
+                self.metabo_graph.add_triplets(triplets)
+                self.metabo_graph.save()
+            except Exception:
+                pass
         after = entropy_of_graph(self.graph.snapshot())
         return before, after
 

--- a/memory/metabo_graph.py
+++ b/memory/metabo_graph.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+from math import log2
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import networkx as nx
+
+
+class MetaboGraph:
+    """Unified network merging multiple knowledge sources."""
+
+    def __init__(self, filepath: str = "data/metabograph.gml") -> None:
+        self.filepath = Path(filepath)
+        self.filepath.parent.mkdir(parents=True, exist_ok=True)
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        """Load existing graph from disk if possible."""
+        if self.filepath.exists():
+            try:
+                g = nx.read_gml(self.filepath)
+                if not isinstance(g, nx.MultiDiGraph):
+                    g = nx.MultiDiGraph(g)
+                self.graph = g
+                return
+            except Exception:
+                pass
+        self.graph = nx.MultiDiGraph()
+
+    def save(self) -> None:
+        """Persist graph to ``filepath``."""
+        try:
+            nx.write_gml(self.graph, self.filepath)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def _merge_node(self, node: str, typ: str | None, source: str | None) -> None:
+        """Create or update ``node`` with given type and source."""
+        attrs = self.graph.nodes.get(node, {})
+        if typ:
+            existing = attrs.get("typ")
+            if existing and typ not in str(existing).split(","):
+                attrs["typ"] = f"{existing},{typ}"
+            elif not existing:
+                attrs["typ"] = typ
+        if source:
+            existing = attrs.get("source")
+            if existing and source not in str(existing).split(","):
+                attrs["source"] = f"{existing},{source}"
+            elif not existing:
+                attrs["source"] = source
+        self.graph.add_node(node, **attrs)
+
+    def add_triplets(
+        self,
+        triplets: Iterable[Tuple[str, str, str]],
+        node_typ: str = "konzept",
+        source: str | None = None,
+    ) -> None:
+        """Insert ``triplets`` with node type and source information."""
+        for subj, rel, obj in triplets:
+            self._merge_node(subj, node_typ, source)
+            self._merge_node(obj, node_typ, source)
+            self.graph.add_edge(subj, obj, relation=rel)
+        self.save()
+
+    def add_graph(
+        self,
+        other: nx.Graph,
+        default_typ: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        """Merge another graph into this one."""
+        for node, data in other.nodes(data=True):
+            typ = data.get("typ", default_typ)
+            self._merge_node(node, typ, data.get("source", source))
+        for u, v, data in other.edges(data=True):
+            self.graph.add_edge(u, v, **data)
+        self.save()
+
+    # ------------------------------------------------------------------
+    def snapshot(self) -> nx.MultiDiGraph:
+        """Return a copy of the underlying graph."""
+        return self.graph.copy()
+
+    def calculate_entropy(self) -> float:
+        """Return Shannon entropy over edge relations."""
+        total = self.graph.number_of_edges()
+        if total == 0:
+            return 0.0
+        counts = {}
+        for _, _, data in self.graph.edges(data=True):
+            rel = data.get("relation", "")
+            counts[rel] = counts.get(rel, 0) + 1
+        entropy = -sum((c / total) * log2(c / total) for c in counts.values())
+        max_ent = log2(len(counts)) if counts else 1.0
+        return entropy / max_ent if max_ent else 0.0
+
+
+def extract_subgraph_by_type(G: nx.Graph, typ: str) -> nx.Graph:
+    """Return subgraph containing only nodes of ``typ``."""
+    nodes = [n for n, d in G.nodes(data=True) if typ in str(d.get("typ", "")).split(",")]
+    return G.subgraph(nodes).copy()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy
 matplotlib
 openai
 pytest
+pyyaml
+

--- a/tests/test_metabograph.py
+++ b/tests/test_metabograph.py
@@ -1,0 +1,24 @@
+import networkx as nx
+from memory.metabo_graph import MetaboGraph, extract_subgraph_by_type
+
+
+def test_merge_and_extract(tmp_path):
+    g1 = nx.MultiDiGraph()
+    g1.add_edge("Musik", "Freude", relation="erzeugt")
+    g2 = nx.MultiDiGraph()
+    g2.add_edge("Musik", "Ziel", relation="fuehrt_zu")
+
+    mg = MetaboGraph(filepath=str(tmp_path / "m.gml"))
+    mg.add_graph(g1, default_typ="konzept", source="user")
+    mg.add_graph(g2, default_typ="intention", source="system")
+
+    assert "konzept" in mg.graph.nodes["Musik"]["typ"]
+    assert "intention" in mg.graph.nodes["Ziel"]["typ"]
+
+    sub = extract_subgraph_by_type(mg.graph, "intention")
+    assert set(sub.nodes()) == {"Musik", "Ziel"}
+
+    ent = mg.calculate_entropy()
+    assert 0.0 <= ent <= 1.0
+
+    assert mg.filepath.exists()


### PR DESCRIPTION
## Summary
- implement `MetaboGraph` for merging existing graphs with node types and sources
- integrate new graph into `MemoryManager`
- add helper `extract_subgraph_by_type`
- document usage in README and extend diagrams
- test MetaboGraph functionality
- ensure graph persistence and document pyyaml requirement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872dfadb130832e912c1c2f88e301e4