### PR TITLE
Merge intent_graph into MetaboGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ a `typ` attribute like `konzept`, `intention` or `emotion` and optional
 functions allow extraction of subgraphs by type and calculation of its Shannon
 entropy.
 
+Old intention graphs stored as `intent_graph.gml` are automatically imported
+when a `MemoryManager` instance is created. Every intention node is marked with
+`typ="intention"` and `source="llm"`; the original file is archived with a
+`.bak` suffix once migration succeeded.
+
 Reflections generated during a MetaboTakt are now also parsed for symbolic
 triples. These triples are stored in the ``MetaboGraph`` and linked to the
 current goal node along with the detected emotion.

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -71,6 +71,7 @@ class MetaboGraph {
   +graph : MultiDiGraph
   +add_graph(graph)
   +add_triplets(triplets)
+  +import_intention_graph(path)
   +calculate_entropy()
   +snapshot()
   +save()

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -22,9 +22,14 @@ class MemoryManager:
         reflection_path: str = "data/last_reflection.txt",
         entropy_path: str = "data/last_entropy.txt",
         meta_path: str = "data/metabograph.gml",
+        intent_graph_path: str | None = None,
     ) -> None:
-        self.graph = IntentionGraph(graph_path)
+        self.graph = IntentionGraph(graph_path, goal_path=intent_graph_path)
         self.metabo_graph = MetaboGraph(meta_path)
+        try:
+            self.metabo_graph.import_intention_graph(self.graph.goal_path)
+        except Exception:
+            pass
         self.emotion_log = Path(emotion_log)
         self.emotion_log.parent.mkdir(parents=True, exist_ok=True)
         self.reflection_path = Path(reflection_path)

--- a/memory/metabo_graph.py
+++ b/memory/metabo_graph.py
@@ -85,6 +85,46 @@ class MetaboGraph:
             self.graph.add_edge(u, v, **data)
         self.save()
 
+    def import_intention_graph(self, path: str | Path) -> None:
+        """Migrate nodes and edges from an existing intention graph."""
+        p = Path(path)
+        if not p.exists():
+            return
+
+        try:
+            g = nx.read_gml(p)
+            if not isinstance(g, nx.MultiDiGraph):
+                g = nx.MultiDiGraph(g)
+        except Exception:
+            return
+
+        for node, data in g.nodes(data=True):
+            self._merge_node(node, "intention", "llm")
+            mode = data.get("mode")
+            if mode:
+                self.graph.nodes[node]["mode"] = mode
+
+        for u, v, data in g.edges(data=True):
+            rel = data.get("relation")
+            exists = False
+            edata = self.graph.get_edge_data(u, v) or {}
+            for d in edata.values() if isinstance(edata, dict) else [edata]:
+                if rel is None or d.get("relation") == rel:
+                    exists = True
+                    break
+            if not exists:
+                attrs = dict(data)
+                attrs.setdefault("relation", rel or "")
+                attrs.setdefault("typ", "relation")
+                self.graph.add_edge(u, v, **attrs)
+
+        self.save()
+        backup = p.with_suffix(p.suffix + ".bak")
+        try:
+            p.rename(backup)
+        except Exception:
+            pass
+
     # ------------------------------------------------------------------
     def snapshot(self) -> nx.MultiDiGraph:
         """Return a copy of the underlying graph."""

--- a/tests/test_intention_migration.py
+++ b/tests/test_intention_migration.py
@@ -1,0 +1,37 @@
+import networkx as nx
+from memory.memory_manager import MemoryManager
+
+
+def test_intention_graph_migration(tmp_path):
+    intent_path = tmp_path / "intent_graph.gml"
+    G = nx.MultiDiGraph()
+    G.add_node("eingabe:hi")
+    G.add_node("intent1", mode="yang")
+    G.add_node("ziel:Musik")
+    G.add_edge("eingabe:hi", "intent1", relation="fuehrt_zu")
+    G.add_edge("intent1", "ziel:Musik", relation="zielt_auf")
+    nx.write_gml(G, intent_path)
+
+    mem = MemoryManager(
+        graph_path=str(tmp_path / "graph.gml"),
+        emotion_log=str(tmp_path / "emo.jsonl"),
+        reflection_path=str(tmp_path / "ref.txt"),
+        entropy_path=str(tmp_path / "ent.txt"),
+        meta_path=str(tmp_path / "meta.gml"),
+        intent_graph_path=str(intent_path),
+    )
+
+    mg = nx.read_gml(mem.metabo_graph.filepath)
+
+    assert "intent1" in mg.nodes
+    data = mg.nodes["intent1"]
+    assert data.get("typ") == "intention"
+    assert data.get("source") == "llm"
+    assert data.get("mode") == "yang"
+
+    assert mg.has_edge("eingabe:hi", "intent1")
+    assert mg.has_edge("intent1", "ziel:Musik")
+
+    # original file archived
+    assert not intent_path.exists()
+    assert intent_path.with_suffix(intent_path.suffix + ".bak").exists()


### PR DESCRIPTION
## Summary
- import old `intent_graph.gml` into the unified graph on startup
- archive migrated files with `.bak`
- expose migration via new `MetaboGraph.import_intention_graph()`
- allow `MemoryManager` to pass custom intent graph paths
- document migration in README
- update class diagram
- test the migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687553ad0b38832e8318fdfefdee7da9