### PR TITLE
Add Yin/Yang mode hints to all LLM prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ All prompts used for LLM interactions are defined centrally in `cfg/config.py`.
 The Metabo rules are stored in `METABO_PROMPT` and automatically prefixed to
 each system prompt.
 
+Every request now includes a `mode_hint` that reflects the active Yin or Yang
+mode. In Yin, the LLM is asked to respond "introspektiv, reflektierend" while in
+Yang the instruction is "zielgerichtet, handlungsbezogen".
+
 Yin and Yang are primarily selected by an LLM via the function
 `decide_yin_yang_mode(user_input, metrics)`.  The metrics include the current
 entropy delta and a rough emotion estimate.  The orchestrator keeps a simple

--- a/control/cycle_manager.py
+++ b/control/cycle_manager.py
@@ -12,6 +12,7 @@ from logs.logger import MetaboLogger
 from parsing.triplet_pipeline import extract_triplets
 
 from reflection.reflection_engine import generate_reflection, run_llm_task
+from control.yin_yang_controller import mode_hint
 from cfg.config import PROMPTS
 
 
@@ -54,6 +55,7 @@ class CycleManager:
             last_reflection=self.memory.load_reflection(),
             triplets=triplets,
             api_key=self.api_key,
+            mode_hint=mode_hint(),
         )
 
     def run_cycle(self, text: str) -> dict:
@@ -76,6 +78,7 @@ class CycleManager:
             user_input=text,
             last_reflection=self.memory.load_reflection(),
             triplets=tuple_triplets,
+            mode_hint=mode_hint(),
         )
 
         goal_message = ""
@@ -91,6 +94,7 @@ class CycleManager:
                     old=self.current_goal, new=new_goal
                 ),
                 api_key=self.api_key,
+                mode_hint=mode_hint(),
             )
             if goal_reflection:
                 self.memory.store_reflection(goal_reflection)

--- a/control/mode_decider.py
+++ b/control/mode_decider.py
@@ -18,6 +18,8 @@ def decide_yin_yang_mode(
     user_input: str,
     metrics: Dict[str, float],
     api_key: str | None = None,
+    *,
+    mode_hint: str | None = None,
 ) -> Optional[Dict[str, str]]:
     """Return an LLM decision for Yin or Yang.
 
@@ -41,10 +43,15 @@ def decide_yin_yang_mode(
         return None
 
     content = f"Eingabe: {user_input}\nMetriken: {json.dumps(metrics)}"
-    messages = [
-        {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": content},
-    ]
+    messages = []
+    if mode_hint:
+        messages.append({"role": "system", "content": mode_hint})
+    messages.extend(
+        [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": content},
+        ]
+    )
     functions = [
         {
             "name": "decide_yin_yang_mode",

--- a/control/yin_yang_controller.py
+++ b/control/yin_yang_controller.py
@@ -137,6 +137,19 @@ class YinYangOrchestrator:
 # Shared orchestrator ---------------------------------------------------
 _ORCHESTRATOR = YinYangOrchestrator()
 
+
+def mode_hint() -> str:
+    """Return a short instruction based on the current mode."""
+    mode = _ORCHESTRATOR.mode
+    if mode == "yin":
+        return (
+            "Bitte antworte introspektiv, reflektierend und auf Verständnis "
+            "ausgerichtet."
+        )
+    return (
+        "Bitte antworte zielgerichtet, lösungsorientiert und handlungsbezogen."
+    )
+
 def decide_mode(
     context_metrics: Dict[str, float], user_input: str, subgoal_count: int = 0
 ) -> str:

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -36,6 +36,7 @@ class YinYangOrchestrator {
   -_next_beat : datetime
   +set_mode(mode)
   +decide_mode(metrics, text, sub_done)
+  +mode_hint()
   +_contains_uncertainty(text)
 }
 class ModeDecider {

--- a/doc/diagrams/sequence_diagram.puml
+++ b/doc/diagrams/sequence_diagram.puml
@@ -17,7 +17,7 @@ MetaboCycle -> GoalManager: get_goal()
 MetaboCycle -> MemoryManager: snapshot()
 MetaboCycle -> GraphEntropyScorer: calculate_entropy()
 GraphEntropyScorer --> MetaboCycle: score
-MetaboCycle -> ReflectionEngine: generate_reflection()
+MetaboCycle -> ReflectionEngine: generate_reflection(mode_hint)
 MetaboCycle -> MemoryManager: add_metabo_insight_to_graph()
 MemoryManager -> MetaboGraph: add_triplets()
 MetaboGraph -> MetaboGraph: save()

--- a/goals/goal_engine.py
+++ b/goals/goal_engine.py
@@ -23,6 +23,8 @@ def generate_next_input(
     previous_reflection: str = "",
     model: str = MODELS['chat'],
     temperature: float = TEMPERATURES['generate_next_input'],
+    *,
+    mode_hint: str | None = None,
 ) -> str:
     """Generate a short statement that pursues ``goal`` further."""
     client = get_client(os.getenv("OPENAI_API_KEY"))
@@ -34,10 +36,13 @@ def generate_next_input(
     if reflection:
         content += f"\nLetzte Reflexion: {reflection}"
 
-    messages = [
+    messages = []
+    if mode_hint:
+        messages.append({"role": "system", "content": mode_hint})
+    messages.extend([
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": content},
-    ]
+    ])
 
     try:
         if hasattr(client, "chat"):

--- a/goals/goal_selector.py
+++ b/goals/goal_selector.py
@@ -31,16 +31,26 @@ def _build_client(api_key: str | None):
     return openai
 
 
-def propose_goal(user_input: str, api_key: str | None = None) -> Optional[str]:
+def propose_goal(
+    user_input: str,
+    api_key: str | None = None,
+    *,
+    mode_hint: str | None = None,
+) -> Optional[str]:
     """Ask the LLM to suggest a new goal based on ``user_input``."""
     client = _build_client(api_key or os.getenv("OPENAI_API_KEY"))
     if client is None:
         return None
 
-    messages = [
-        {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": user_input},
-    ]
+    messages = []
+    if mode_hint:
+        messages.append({"role": "system", "content": mode_hint})
+    messages.extend(
+        [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_input},
+        ]
+    )
     functions = [
         {
             "name": "propose_goal",

--- a/goals/subgoal_planner.py
+++ b/goals/subgoal_planner.py
@@ -20,6 +20,7 @@ def decompose_goal(
     *,
     model: str = MODELS['subgoal'],
     temperature: float = TEMPERATURES['subgoal'],
+    mode_hint: str | None = None,
 ) -> List[str]:
     """Return a list of subgoals decomposed from ``goal``."""
     client = get_client(os.getenv("OPENAI_API_KEY"))
@@ -30,10 +31,13 @@ def decompose_goal(
     if context:
         user_content += f"\nKontext: {context}"
 
-    messages = [
+    messages = []
+    if mode_hint:
+        messages.append({"role": "system", "content": mode_hint})
+    messages.extend([
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": user_content},
-    ]
+    ])
 
     try:
         if hasattr(client, "chat"):

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from goals.goal_updater import update_goal
 from interface.metabo_gui import MetaboGUI
 import utils.llm_client as llm_client
 from memory.memory_manager import get_memory_manager
-from control.yin_yang_controller import current_mode
+from control.yin_yang_controller import current_mode, mode_hint as yin_yang_mode_hint
 
 
 def print_help() -> None:
@@ -60,6 +60,7 @@ def main() -> None:
             last_goal=result.get("goal", ""),
             last_reflection=result.get("reflection", ""),
             triplets=result.get("triplets", []),
+            mode_hint=yin_yang_mode_hint(),
         )
         set_goal(new_goal)
         print("[Zyklus abgeschlossen]")

--- a/tests/engine/test_metabo_cycle_engine.py
+++ b/tests/engine/test_metabo_cycle_engine.py
@@ -47,7 +47,7 @@ def setup(monkeypatch):
     monkeypatch.setattr(metabo_engine, "recall_context", lambda *a, **k: [])
     monkeypatch.setattr(metabo_engine, "generate_reflection", lambda **k: {"reflection": ""})
     monkeypatch.setattr(metabo_engine, "extract_triplets", lambda text, source="reflection": [])
-    monkeypatch.setattr(metabo_engine, "propose_goal", lambda ui: None)
+    monkeypatch.setattr(metabo_engine, "propose_goal", lambda ui, **kw: None)
     monkeypatch.setattr(metabo_engine, "check_goal_shift", lambda a, b: False)
     path = os.path.join(os.getcwd(), "tmp_goal.txt")
     refl = os.path.join(os.getcwd(), "tmp_ref.txt")

--- a/tests/test_cycle_manager.py
+++ b/tests/test_cycle_manager.py
@@ -19,7 +19,7 @@ def test_goal_switch(monkeypatch):
     setup_common(monkeypatch, cm)
     monkeypatch.setattr(
         "control.cycle_manager.goal_engine.update_goal",
-        lambda user_input, last_reflection, triplets: "Neu",
+        lambda user_input, last_reflection, triplets, **kw: "Neu",
     )
     cm.current_goal = "Alt"
     res = cm.run_cycle("irgendwas")

--- a/tests/test_goal_updater.py
+++ b/tests/test_goal_updater.py
@@ -43,7 +43,7 @@ def test_explicit_command(monkeypatch):
 
 def test_proposed_goal_via_llm(monkeypatch):
     monkeypatch.setattr(goal_updater, "_extract_explicit_goal", lambda t: None)
-    monkeypatch.setattr(goal_updater, "propose_goal", lambda t: "Neu")
+    monkeypatch.setattr(goal_updater, "propose_goal", lambda t, **kw: "Neu")
     monkeypatch.setattr(goal_updater, "check_goal_shift", lambda a, b: True)
     monkeypatch.setattr(goal_updater, "get_client", lambda *a, **k: None)
     res = goal_updater.update_goal("hi", "Alt", "", [])

--- a/tests/test_graph_integration.py
+++ b/tests/test_graph_integration.py
@@ -44,7 +44,7 @@ def setup_env(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 # Dummy LLM behaviour
 
-def dummy_propose_goal(user_input, api_key=None):
+def dummy_propose_goal(user_input, api_key=None, **kwargs):
     if "klassischer Musik" in user_input:
         return "klassische Musik"
     return None

--- a/tests/test_metabo_cycle.py
+++ b/tests/test_metabo_cycle.py
@@ -59,7 +59,7 @@ def setup(monkeypatch, tmp_path, goal=""):
 
 def test_goal_switch(monkeypatch, tmp_path):
     setup(monkeypatch, tmp_path, goal="Alt")
-    monkeypatch.setattr(metabo_cycle, "propose_goal", lambda ui: "Neu")
+    monkeypatch.setattr(metabo_cycle, "propose_goal", lambda ui, **kw: "Neu")
     monkeypatch.setattr(metabo_cycle, "check_goal_shift", lambda a, b: True)
     res = metabo_cycle.run_metabo_cycle("User input", source_type="user")
     assert res["goal"] == "Neu"

--- a/tests/test_takt_engine.py
+++ b/tests/test_takt_engine.py
@@ -61,7 +61,7 @@ def setup(monkeypatch, change_goal=False):
             super().__init__(path=path, reflection_path=refl)
     monkeypatch.setattr(metabo_engine, "GoalManager", DummyGM)
     DummyGM().set_goal("A")
-    monkeypatch.setattr(metabo_engine, "propose_goal", lambda ui: None)
+    monkeypatch.setattr(metabo_engine, "propose_goal", lambda ui, **kw: None)
     monkeypatch.setattr(metabo_engine, "check_goal_shift", lambda a, b: False)
     monkeypatch.setattr(metabo_engine, "is_new_topic", lambda u, g: False)
     monkeypatch.setattr(metabo_engine, "run_llm_task", lambda *a, **k: "ref")


### PR DESCRIPTION
## Summary
- expose `mode_hint()` in `yin_yang_controller` to supply short Yin/Yang instructions
- inject `mode_hint` into every LLM request
- adapt Metabo engine and managers to forward the hint
- update diagrams and documentation
- adjust tests for new keyword arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875729f0868832eb87098c096326c49