### PR TITLE
Unify metabograph handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 secrets/
 **/__pycache__
-data/graph.gml
+data/metabograph.gml
 data/metabo_log.jsonl
-memory/intent_graph.gml
 *.txt
 runMetaboMind.sh
 *.zip

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ MetaboMind is a simple goal-oriented reasoning demo. The main entry point is
 `main.py` which launches a small GUI and handles the cycle logic.
 
 Runtime data such as logs or graphs are stored in the `data/` directory.
+Triples extracted from reflections and user input are merged via `process_triples` into `data/metabograph.gml`.
 
 ## Diagrams
 
 ### Class overview
 
-![Class Diagram](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuKhEIImkLl1DpCo3CLDB4fFodIkJSrAX8kxvYJc-YNc9wQb5S3Mv-KMLg6AUUIMfUIMP-NdkHOa56L31eDIqdDHaaAXhNdfc7ip4aCJi4gW0o6O5NLqx57kHs60vP1UWow6w1LqMmm4eoi5Aq1oES1iMuz4aaTtba9gN0WfG0000)
+![Class Diagram](https://www.plantuml.com/plantuml/png/bZFLDsIwDET3nKIX6BVQJYSqLrpBcAAT3BLhOigxi94epUrIp-xGM47nWemcgJXPQgdF4FwzguYoUeBuTqsiDE5vgEZgmNH-ZhZj19IbWJBFG-4tvJ_xqdc30eSCccGJUPmxM8-aY8UVXhIMj9K07bEAyfSW5Uh1VsLV6Q5gtzohF5u2sDoyYf9prsIcuY5SZYf88N_yBQ)
 
 ### Cycle sequence
 

--- a/control/takt_engine.py
+++ b/control/takt_engine.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from goals import goal_engine
 from memory.memory_manager import get_memory_manager
+from memory.graph_utils import process_triples
 from reflection.reflection_engine import run_llm_task
 
 
@@ -12,36 +13,40 @@ def run_metabotakt(api_key: str | None = None) -> Dict[str, object]:
     memory = get_memory_manager()
     current_goal = goal_engine.get_current_goal()
 
-    last_entropy = memory.load_last_entropy()
-    current_entropy = memory.calculate_entropy()
-    delta = current_entropy - last_entropy
-    memory.store_last_entropy(current_entropy)
-
-    emotion = memory.map_entropy_to_emotion(delta)
+    before = memory.calculate_entropy()
 
     prompt = (
-        f"Reflektiere den aktuellen Stand: Ziel war {current_goal}, "
-        f"\u0394E war {delta:+.2f}. Welche Bedeutung hat das?"
+        f"Reflektiere den aktuellen Stand: Ziel war {current_goal}."
     )
     reflection = run_llm_task(prompt, api_key=api_key)
+
+    triple_data = process_triples(reflection, source="reflection") if reflection else {
+        "triplets": [], "entropy_before": before, "entropy_after": before
+    }
+
     if reflection:
         memory.store_reflection(reflection)
+
+    after = triple_data["entropy_after"]
+    memory.store_last_entropy(after)
+    delta = after - before
+    emotion = memory.map_entropy_to_emotion(delta)
 
     new_goal = goal_engine.update_goal(
         user_input=reflection,
         last_reflection=reflection,
-        triplets=[],
+        triplets=triple_data["triplets"],
     )
     goal_update = ""
     if new_goal != current_goal:
-        memory.graph.add_goal_transition(current_goal, new_goal)
+        memory.graph.add_goal_transition(current_goal or None, new_goal)
         current_goal = new_goal
         goal_update = f"Neues Ziel erkannt: {new_goal}"
 
     return {
         "goal": current_goal,
         "goal_update": goal_update,
-        "entropy": current_entropy,
+        "entropy": after,
         "delta": delta,
         "emotion": emotion["emotion"],
         "intensity": emotion["intensity"],

--- a/doc/diagrams/class_diagram.puml
+++ b/doc/diagrams/class_diagram.puml
@@ -4,13 +4,16 @@ class MetaboCycle
 class GoalManager
 class MemoryManager
 class IntentionGraph
+class GraphUtils
 class ReflectionEngine
 class TaktEngine
 Main --> MetaboCycle
 MetaboCycle --> GoalManager
 MetaboCycle --> MemoryManager
 MetaboCycle --> ReflectionEngine
+MetaboCycle --> GraphUtils
 MemoryManager --> IntentionGraph
 TaktEngine --> MemoryManager
 TaktEngine --> GoalManager
+TaktEngine --> GraphUtils
 @enduml

--- a/memory/graph_manager.py
+++ b/memory/graph_manager.py
@@ -6,7 +6,7 @@ from memory.intention_graph import IntentionGraph
 class GraphManager:
     """Lightweight wrapper for ``IntentionGraph`` access."""
 
-    def __init__(self, filepath: str = "data/graph.gml") -> None:
+    def __init__(self, filepath: str = "data/metabograph.gml") -> None:
         self.intention_graph = IntentionGraph(filepath)
 
     def snapshot(self):
@@ -14,6 +14,9 @@ class GraphManager:
 
     def add_triplets(self, triplets) -> None:
         self.intention_graph.add_triplets(triplets)
+
+    def add_goal_transition(self, previous: str | None, new_goal: str) -> None:
+        self.intention_graph.add_goal_transition(previous, new_goal)
 
     def save(self) -> None:
         self.intention_graph.save_graph()

--- a/memory/graph_utils.py
+++ b/memory/graph_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from typing import List, Tuple
+
+from parsing.triplet_parser_llm import extract_triplets_via_llm
+from memory.memory_manager import get_memory_manager
+
+
+def _find_similar_node(name: str, nodes: list[str], threshold: float = 0.8) -> str:
+    """Return an existing node name with high similarity to ``name`` if found."""
+    best = name
+    best_score = threshold
+    for node in nodes:
+        score = SequenceMatcher(None, node.lower(), name.lower()).ratio()
+        if score >= best_score:
+            best = node
+            best_score = score
+    return best
+
+
+def process_triples(text: str, source: str = "reflection") -> dict:
+    """Extract triples from ``text`` and integrate them into the metabograph."""
+    triples = extract_triplets_via_llm(text)
+    memory = get_memory_manager()
+    graph = memory.graph
+    existing = list(graph.graph.nodes)
+    processed: List[Tuple[str, str, str]] = []
+    for subj, rel, obj in triples:
+        s = _find_similar_node(subj, existing)
+        o = _find_similar_node(obj, existing)
+        processed.append((s, rel, o))
+        existing.extend([s, o])
+    before, after = memory.store_triplets(processed)
+    graph.save_graph()
+    return {"triplets": processed, "entropy_before": before, "entropy_after": after}
+

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -15,7 +15,7 @@ class MemoryManager:
 
     def __init__(
         self,
-        graph_path: str = "data/graph.gml",
+        graph_path: str = "data/metabograph.gml",
         emotion_log: str = "data/emotions.jsonl",
         reflection_path: str = "memory/last_reflection.txt",
         entropy_path: str = "memory/last_entropy.txt",

--- a/reflection/reflection_engine.py
+++ b/reflection/reflection_engine.py
@@ -152,11 +152,7 @@ def generate_reflection(
     memory = get_memory_manager()
     if changed and proposed and proposed.strip() and proposed != goal:
         logger.info("Neues Ziel erkannt: %s -> %s", goal, proposed)
-        if goal:
-            memory.graph.add_goal_transition(goal, proposed)
-        else:
-            memory.graph.goal_graph.add_node(proposed)
-            memory.graph._save_goal_graph()
+        memory.graph.add_goal_transition(goal or None, proposed)
         goal_manager.set_goal(proposed)
         goal_update_msg = run_llm_task(
             f"Reflektiere kurz den Zielwechsel von '{goal}' zu '{proposed}'.",

--- a/tests/test_cycle_manager.py
+++ b/tests/test_cycle_manager.py
@@ -6,9 +6,8 @@ from control.cycle_manager import CycleManager
 
 
 def setup_common(monkeypatch, cm):
-    monkeypatch.setattr(cm.memory.graph, "_save_goal_graph", lambda: None)
     monkeypatch.setattr(cm.memory.graph, "save_graph", lambda: None)
-    monkeypatch.setattr("control.cycle_manager.extract_triplets_via_llm", lambda text: [])
+    monkeypatch.setattr("control.cycle_manager.process_triples", lambda text, source="user_input": {"triplets": [], "entropy_before": 0.0, "entropy_after": 0.0})
     monkeypatch.setattr("control.cycle_manager.generate_reflection", lambda **k: {"reflection": ""})
     monkeypatch.setattr(cm.memory, "save_emotion", lambda *a, **k: {"delta": 0.0, "emotion": "neutral", "intensity": "low"})
     monkeypatch.setattr(cm.memory, "store_reflection", lambda text: None)

--- a/tests/test_metabo_cycle.py
+++ b/tests/test_metabo_cycle.py
@@ -18,8 +18,6 @@ def setup(monkeypatch, tmp_path, goal=""):
             pass
         def add_goal_transition(self, a, b):
             self.goal_graph.add_edge(a, b)
-        def _save_goal_graph(self):
-            pass
 
     mem = types.SimpleNamespace(graph=DummyGraph())
     monkeypatch.setattr(metabo_cycle, "get_memory_manager", lambda: mem)
@@ -29,7 +27,7 @@ def setup(monkeypatch, tmp_path, goal=""):
     monkeypatch.setattr(metabo_cycle, "load_context", lambda g, goal: [])
     monkeypatch.setattr(metabo_cycle, "recall_context", lambda scope="goal", limit=5: [])
     monkeypatch.setattr(metabo_cycle, "generate_reflection", lambda **k: {"reflection": ""})
-    monkeypatch.setattr(metabo_cycle, "extract_triplets_via_llm", lambda text: [])
+    monkeypatch.setattr(metabo_cycle, "process_triples", lambda text, source="reflection": {"triplets": [], "entropy_before": 0.0, "entropy_after": 0.0})
 
     path = tmp_path / "goal.txt"
     refl = tmp_path / "ref.txt"

--- a/tests/test_reflection_engine.py
+++ b/tests/test_reflection_engine.py
@@ -20,9 +20,7 @@ def setup_common(monkeypatch):
     monkeypatch.setattr(reflection_engine, "run_llm_task", lambda *a, **k: "note")
     mem = types.SimpleNamespace(
         graph=types.SimpleNamespace(
-            add_goal_transition=lambda a,b: setattr(mem, "edge", (a,b)),
-            goal_graph=types.SimpleNamespace(add_node=lambda n: None),
-            _save_goal_graph=lambda: None,
+            add_goal_transition=lambda a, b: setattr(mem, "edge", (a, b)),
         )
     )
     monkeypatch.setattr(reflection_engine, "get_memory_manager", lambda: mem)

--- a/tests/test_takt_engine.py
+++ b/tests/test_takt_engine.py
@@ -10,7 +10,11 @@ from control import takt_engine
 class DummyMem:
     def __init__(self):
         self.val = 0.0
-        self.graph = types.SimpleNamespace(add_goal_transition=lambda a,b: None)
+        self.graph = types.SimpleNamespace(
+            add_goal_transition=lambda a, b: None,
+            graph=types.SimpleNamespace(nodes=[]),
+            save_graph=lambda: None,
+        )
 
     def calculate_entropy(self):
         return 0.4
@@ -24,6 +28,9 @@ class DummyMem:
     def map_entropy_to_emotion(self, delta):
         return {"delta": delta, "emotion": "neutral", "intensity": "low"}
 
+    def store_triplets(self, triplets):
+        return 0.4, 0.4
+
     def store_reflection(self, reflection):
         self.reflection = reflection
 
@@ -34,6 +41,8 @@ class DummyMem:
 def setup(monkeypatch, change_goal=False):
     mem = DummyMem()
     monkeypatch.setattr(takt_engine, "get_memory_manager", lambda: mem)
+    import memory.graph_utils as graph_utils
+    monkeypatch.setattr(graph_utils, "get_memory_manager", lambda: mem)
     monkeypatch.setattr(takt_engine.goal_engine, "get_current_goal", lambda: "A")
     if change_goal:
         monkeypatch.setattr(takt_engine.goal_engine, "update_goal", lambda **k: "B")


### PR DESCRIPTION
## Summary
- centralize graph operations in `process_triples`
- store knowledge in `data/metabograph.gml`
- adjust cycle logic and takt engine to use the new helper
- clean up legacy goal graph usage
- update diagrams and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687578476f04832eb3d0d937d5226039